### PR TITLE
Add missing construct-lift, map, and tap functions

### DIFF
--- a/src/trcks/fp/monads/awaitable_result_tuple.py
+++ b/src/trcks/fp/monads/awaitable_result_tuple.py
@@ -431,7 +431,7 @@ def map_failure_to_awaitable(
 
 
 def map_failure_to_awaitable_iterable(
-    f: Callable[[_F1], Awaitable[Iterable[_S2]]],
+    f: Callable[[_F1], AwaitableIterable[_S2]],
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     Awaitable[SuccessTuple[_S1] | SuccessTuple[_S2]],
@@ -862,7 +862,7 @@ def map_successes_to_awaitable(
 
 
 def map_successes_to_awaitable_iterable(
-    f: Callable[[_S1], Awaitable[Iterable[_S2]]],
+    f: Callable[[_S1], AwaitableIterable[_S2]],
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S2]]:
     """Map an awaitable-[collections.abc.Iterable][]-returning function
     over each element in a [trcks.AwaitableResultTuple][].
@@ -1267,7 +1267,7 @@ def tap_failure_to_awaitable(
 
 
 def tap_failure_to_awaitable_iterable(
-    f: Callable[[_F1], Awaitable[Iterable[object]]],
+    f: Callable[[_F1], AwaitableIterable[object]],
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     Awaitable[SuccessTuple[_F1] | SuccessTuple[_S1]],
@@ -1708,7 +1708,7 @@ def tap_successes_to_awaitable(
 
 
 def tap_successes_to_awaitable_iterable(
-    f: Callable[[_S1], Awaitable[Iterable[object]]],
+    f: Callable[[_S1], AwaitableIterable[object]],
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S1]]:
     """Apply an asynchronous [collections.abc.Iterable][]-returning side effect
     to each element in a [trcks.AwaitableResultTuple][].

--- a/src/trcks/fp/monads/awaitable_result_tuple.py
+++ b/src/trcks/fp/monads/awaitable_result_tuple.py
@@ -188,7 +188,7 @@ def construct_from_awaitable_result_iterable(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl))
         ('success', (1, 2))
     """
-    return a.map_(r.map_success(tuple))(a_r_it)
+    return a.map_(rt.construct_from_result_iterable)(a_r_it)
 
 
 def construct_from_result(rslt: Result[_F, _S]) -> AwaitableResultTuple[_F, _S]:

--- a/src/trcks/fp/monads/awaitable_result_tuple.py
+++ b/src/trcks/fp/monads/awaitable_result_tuple.py
@@ -179,7 +179,7 @@ def construct_from_awaitable_result_iterable(
         >>> from trcks.fp.monads import awaitable_result_tuple as art
         >>> async def slowly_read_from_disk() -> ResultIterable[str, int]:
         ...     await asyncio.sleep(0.001)
-        ...     return "success", (1, 2)
+        ...     return "success", [1, 2]
         ...
         >>> a_r_tpl = art.construct_from_awaitable_result_iterable(
         ...     slowly_read_from_disk()
@@ -319,7 +319,7 @@ def construct_successes_from_awaitable_iterable(
         >>> from trcks import AwaitableIterable
         >>> from trcks.fp.monads import awaitable as a
         >>> from trcks.fp.monads import awaitable_result_tuple as art
-        >>> a_it: AwaitableIterable[int] = a.construct((1, 2))
+        >>> a_it: AwaitableIterable[int] = a.construct([1, 2])
         >>> a_r_tpl = art.construct_successes_from_awaitable_iterable(a_it)
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl))
         ('success', (1, 2))
@@ -453,26 +453,26 @@ def map_failure_to_awaitable_iterable(
     Example:
         >>> import asyncio
         >>> from trcks.fp.monads import awaitable_result_tuple as art
-        >>> async def _slowly_recover_from_not_found(
+        >>> async def _slowly_recover_from_failure(
         ...     description: str,
-        ... ) -> tuple[int, ...]:
+        ... ) -> list[int]:
         ...     await asyncio.sleep(0.001)
         ...     if description == "not found":
-        ...         return (0,)
-        ...     return ()
+        ...         return [0]
+        ...     return []
         ...
-        >>> slowly_recover_from_not_found = art.map_failure_to_awaitable_iterable(
-        ...     _slowly_recover_from_not_found
+        >>> slowly_recover_from_failure = art.map_failure_to_awaitable_iterable(
+        ...     _slowly_recover_from_failure
         ... )
-        >>> a_r_tpl_1 = slowly_recover_from_not_found(
+        >>> a_r_tpl_1 = slowly_recover_from_failure(
         ...     art.construct_failure("not found")
         ... )
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_1))
         ('success', (0,))
-        >>> a_r_tpl_2 = slowly_recover_from_not_found(art.construct_failure("fatal"))
+        >>> a_r_tpl_2 = slowly_recover_from_failure(art.construct_failure("fatal"))
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_2))
         ('success', ())
-        >>> a_r_tpl_3 = slowly_recover_from_not_found(
+        >>> a_r_tpl_3 = slowly_recover_from_failure(
         ...     art.construct_successes_from_iterable((1, 2))
         ... )
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_3))
@@ -537,7 +537,7 @@ def map_failure_to_awaitable_result(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_2))
         ('failure', 'fatal')
         >>> a_r_tpl_3 = slowly_recover_from_not_found(
-        ...     art.construct_successes_from_iterable((1, 2))
+        ...     art.construct_successes_from_iterable([1, 2])
         ... )
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_3))
         ('success', (1, 2))
@@ -624,6 +624,19 @@ def map_failure_to_awaitable_result_tuple(
     [trcks.fp.monads.awaitable_result_tuple.map_failure_to_awaitable_result_iterable][].
     """
     return map_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+
+
+@deprecated("Use map_failure_to_awaitable_iterable instead")
+def map_failure_to_awaitable_tuple(
+    f: Callable[[_F1], Awaitable[tuple[_S2, ...]]],
+) -> Callable[
+    [AwaitableResultTuple[_F1, _S1]],
+    Awaitable[SuccessTuple[_S1] | SuccessTuple[_S2]],
+]:
+    """Deprecated alias for
+    [trcks.fp.monads.awaitable_result_tuple.map_failure_to_awaitable_iterable][].
+    """
+    return map_failure_to_awaitable_iterable(f)  # pragma: no cover
 
 
 def map_failure_to_iterable(
@@ -887,7 +900,7 @@ def map_successes_to_awaitable_iterable(
         ...     _slowly_duplicate_integer
         ... )
         >>> a_r_tpl_1 = slowly_duplicate_integers(
-        ...     art.construct_successes_from_iterable((1, 2))
+        ...     art.construct_successes_from_iterable([1, 2])
         ... )
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_1))
         ('success', (1, 1, 2, 2))
@@ -1047,6 +1060,16 @@ def map_successes_to_awaitable_result_tuple(
     [trcks.fp.monads.awaitable_result_tuple.map_successes_to_awaitable_result_iterable][].
     """
     return map_successes_to_awaitable_result_iterable(f)  # pragma: no cover
+
+
+@deprecated("Use map_successes_to_awaitable_iterable instead")
+def map_successes_to_awaitable_tuple(
+    f: Callable[[_S1], Awaitable[tuple[_S2, ...]]],
+) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S2]]:
+    """Deprecated alias for
+    [trcks.fp.monads.awaitable_result_tuple.map_successes_to_awaitable_iterable][].
+    """
+    return map_successes_to_awaitable_iterable(f)  # pragma: no cover
 
 
 def map_successes_to_iterable(
@@ -1311,15 +1334,15 @@ def tap_failure_to_awaitable_iterable(
         >>> r_tpl_1
         ('success', ('critical', 'critical'))
         >>> a_r_tpl_2 = slowly_log_and_alert(
-        ...     art.construct_successes_from_iterable((1,))
+        ...     art.construct_successes_from_iterable([1])
         ... )
         >>> r_tpl_2 = asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_2))
         >>> r_tpl_2
         ('success', (1,))
     """
 
-    async def bypassed_f(value: _F1) -> tuple[_F1, ...]:
-        return tuple(value for _ in await f(value))
+    async def bypassed_f(value: _F1) -> list[_F1]:
+        return [value for _ in await f(value)]
 
     return map_failure_to_awaitable_iterable(bypassed_f)
 
@@ -1456,6 +1479,19 @@ def tap_failure_to_awaitable_result_tuple(
     [trcks.fp.monads.awaitable_result_tuple.tap_failure_to_awaitable_result_iterable][].
     """
     return tap_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+
+
+@deprecated("Use tap_failure_to_awaitable_iterable instead")
+def tap_failure_to_awaitable_tuple(
+    f: Callable[[_F1], Awaitable[tuple[object, ...]]],
+) -> Callable[
+    [AwaitableResultTuple[_F1, _S1]],
+    Awaitable[SuccessTuple[_F1] | SuccessTuple[_S1]],
+]:
+    """Deprecated alias for
+    [trcks.fp.monads.awaitable_result_tuple.tap_failure_to_awaitable_iterable][].
+    """
+    return tap_failure_to_awaitable_iterable(f)  # pragma: no cover
 
 
 def tap_failure_to_iterable(
@@ -1736,7 +1772,7 @@ def tap_successes_to_awaitable_iterable(
         >>> slowly_log_twice = art.tap_successes_to_awaitable_iterable(
         ...     _slowly_log_twice
         ... )
-        >>> a_r_tpl = slowly_log_twice(art.construct_successes_from_iterable((7,)))
+        >>> a_r_tpl = slowly_log_twice(art.construct_successes_from_iterable([7]))
         >>> r_tpl = asyncio.run(art.to_coroutine_result_tuple(a_r_tpl))
         Received: 7
         Received: 7
@@ -1744,8 +1780,8 @@ def tap_successes_to_awaitable_iterable(
         ('success', (7, 7))
     """
 
-    async def bypassed_f(value: _S1) -> tuple[_S1, ...]:
-        return tuple(value for _ in await f(value))
+    async def bypassed_f(value: _S1) -> list[_S1]:
+        return [value for _ in await f(value)]
 
     return map_successes_to_awaitable_iterable(bypassed_f)
 
@@ -1875,6 +1911,16 @@ def tap_successes_to_awaitable_result_tuple(
     [trcks.fp.monads.awaitable_result_tuple.tap_successes_to_awaitable_result_iterable][].
     """
     return tap_successes_to_awaitable_result_iterable(f)  # pragma: no cover
+
+
+@deprecated("Use tap_successes_to_awaitable_iterable instead")
+def tap_successes_to_awaitable_tuple(
+    f: Callable[[_S1], Awaitable[tuple[object, ...]]],
+) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S1]]:
+    """Deprecated alias for
+    [trcks.fp.monads.awaitable_result_tuple.tap_successes_to_awaitable_iterable][].
+    """
+    return tap_successes_to_awaitable_iterable(f)  # pragma: no cover
 
 
 def tap_successes_to_iterable(

--- a/src/trcks/fp/monads/awaitable_result_tuple.py
+++ b/src/trcks/fp/monads/awaitable_result_tuple.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
 
     from trcks import (
         AwaitableFailure,
+        AwaitableIterable,
         AwaitableResult,
         AwaitableResultIterable,
         AwaitableResultTuple,
@@ -158,6 +159,37 @@ def construct_from_awaitable_result(
     return a.map_(rt.construct_from_result)(a_rslt)
 
 
+def construct_from_awaitable_result_iterable(
+    a_r_it: AwaitableResultIterable[_F, _S],
+) -> AwaitableResultTuple[_F, _S]:
+    """Create a [trcks.AwaitableResultTuple][] object
+    from a [trcks.AwaitableResultIterable][] object.
+
+    Args:
+        a_r_it: [trcks.AwaitableResultIterable][] object to be converted.
+
+    Returns:
+        A new [trcks.AwaitableResultTuple][] instance where
+            the success payload is converted to a tuple,
+            or the original failure is preserved.
+
+    Example:
+        >>> import asyncio
+        >>> from trcks import ResultIterable
+        >>> from trcks.fp.monads import awaitable_result_tuple as art
+        >>> async def slowly_read_from_disk() -> ResultIterable[str, int]:
+        ...     await asyncio.sleep(0.001)
+        ...     return "success", (1, 2)
+        ...
+        >>> a_r_tpl = art.construct_from_awaitable_result_iterable(
+        ...     slowly_read_from_disk()
+        ... )
+        >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl))
+        ('success', (1, 2))
+    """
+    return a.map_(r.map_success(tuple))(a_r_it)
+
+
 def construct_from_result(rslt: Result[_F, _S]) -> AwaitableResultTuple[_F, _S]:
     """Create a [trcks.AwaitableResultTuple][] object from a [trcks.Result][].
 
@@ -208,7 +240,7 @@ def construct_from_result_iterable(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl))
         ('success', (1, 2))
     """
-    return a.construct(r.map_success(tuple)(r_it))
+    return a.construct(rt.construct_from_result_iterable(r_it))
 
 
 @deprecated("Use construct_from_result_iterable instead")
@@ -267,6 +299,32 @@ def construct_successes_from_awaitable(
         ('success', (7,))
     """
     return a.map_(rt.construct_successes)(awtbl)
+
+
+def construct_successes_from_awaitable_iterable(
+    a_it: AwaitableIterable[_S],
+) -> AwaitableSuccessTuple[_S]:
+    """Create a [trcks.AwaitableSuccessTuple][] object
+    from a [trcks.AwaitableIterable][] object.
+
+    Args:
+        a_it: [trcks.AwaitableIterable][] object to be converted.
+
+    Returns:
+        A new [trcks.AwaitableSuccessTuple][] instance containing
+            the elements of the given [trcks.AwaitableIterable][] object.
+
+    Example:
+        >>> import asyncio
+        >>> from trcks import AwaitableIterable
+        >>> from trcks.fp.monads import awaitable as a
+        >>> from trcks.fp.monads import awaitable_result_tuple as art
+        >>> a_it: AwaitableIterable[int] = a.construct((1, 2))
+        >>> a_r_tpl = art.construct_successes_from_awaitable_iterable(a_it)
+        >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl))
+        ('success', (1, 2))
+    """
+    return a.map_(rt.construct_successes_from_iterable)(a_it)
 
 
 def construct_successes_from_iterable(
@@ -369,6 +427,123 @@ def map_failure_to_awaitable(
     """
     return map_failure_to_awaitable_result_iterable(
         compose2((f, construct_failure_from_awaitable))
+    )
+
+
+def map_failure_to_awaitable_iterable(
+    f: Callable[[_F1], Awaitable[Iterable[_S2]]],
+) -> Callable[
+    [AwaitableResultTuple[_F1, _S1]],
+    Awaitable[SuccessTuple[_S1] | SuccessTuple[_S2]],
+]:
+    """Create function that maps [trcks.AwaitableFailure][] values
+    to awaitable [collections.abc.Iterable][]s.
+
+    [trcks.AwaitableSuccessTuple][] values are left unchanged.
+
+    Args:
+        f: Asynchronous function to apply to the [trcks.AwaitableFailure][] values.
+
+    Returns:
+        Maps [trcks.AwaitableFailure][] values to [collections.abc.Iterable][]s
+            wrapped in [trcks.AwaitableSuccessTuple][] values
+            according to the given asynchronous function and
+            leaves [trcks.AwaitableSuccessTuple][] values unchanged.
+
+    Example:
+        >>> import asyncio
+        >>> from trcks.fp.monads import awaitable_result_tuple as art
+        >>> async def _slowly_recover_from_not_found(
+        ...     description: str,
+        ... ) -> tuple[int, ...]:
+        ...     await asyncio.sleep(0.001)
+        ...     if description == "not found":
+        ...         return (0,)
+        ...     return ()
+        ...
+        >>> slowly_recover_from_not_found = art.map_failure_to_awaitable_iterable(
+        ...     _slowly_recover_from_not_found
+        ... )
+        >>> a_r_tpl_1 = slowly_recover_from_not_found(
+        ...     art.construct_failure("not found")
+        ... )
+        >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_1))
+        ('success', (0,))
+        >>> a_r_tpl_2 = slowly_recover_from_not_found(art.construct_failure("fatal"))
+        >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_2))
+        ('success', ())
+        >>> a_r_tpl_3 = slowly_recover_from_not_found(
+        ...     art.construct_successes_from_iterable((1, 2))
+        ... )
+        >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_3))
+        ('success', (1, 2))
+    """
+
+    async def mapped_f(
+        r_tpl: ResultTuple[_F1, _S1],
+    ) -> SuccessTuple[_S1] | SuccessTuple[_S2]:
+        match r_tpl:
+            case ("failure", value):
+                return "success", tuple(await f(value))  # pyrefly: ignore[bad-argument-type]
+            case ("success", _):
+                return r_tpl
+            case _:  # pragma: no cover
+                assert_type(r_tpl, Never)  # type: ignore[unreachable]  # pyright: ignore[reportUnreachable]  # pyrefly: ignore [assert-type]
+                msg = f"{type(r_tpl).__name__!r} is not a valid ResultTuple"
+                raise TypeError(msg)
+
+    return a.map_to_awaitable(mapped_f)
+
+
+def map_failure_to_awaitable_result(
+    f: Callable[[_F1], AwaitableResult[_F2, _S2]],
+) -> Callable[
+    [AwaitableResultTuple[_F1, _S1]],
+    AwaitableResultTuple[_F2, _S1 | _S2],
+]:
+    """Create function that maps [trcks.AwaitableFailure][] values
+    to [trcks.AwaitableResultTuple][] values.
+
+    [trcks.AwaitableSuccessTuple][] values are left unchanged.
+
+    Args:
+        f: Asynchronous function to apply to the [trcks.AwaitableFailure][] values.
+
+    Returns:
+        Maps [trcks.AwaitableFailure][] values to new
+            [trcks.AwaitableResultTuple][] values
+            according to the given asynchronous function and
+            leaves [trcks.AwaitableSuccessTuple][] values unchanged.
+
+    Example:
+        >>> import asyncio
+        >>> from trcks import Result
+        >>> from trcks.fp.monads import awaitable_result_tuple as art
+        >>> async def _slowly_recover_from_not_found(e: str) -> Result[str, int]:
+        ...     await asyncio.sleep(0.001)
+        ...     if e == "not found":
+        ...         return "success", 0
+        ...     return "failure", e
+        ...
+        >>> slowly_recover_from_not_found = art.map_failure_to_awaitable_result(
+        ...     _slowly_recover_from_not_found
+        ... )
+        >>> a_r_tpl_1 = slowly_recover_from_not_found(
+        ...     art.construct_failure("not found")
+        ... )
+        >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_1))
+        ('success', (0,))
+        >>> a_r_tpl_2 = slowly_recover_from_not_found(art.construct_failure("fatal"))
+        >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_2))
+        ('failure', 'fatal')
+        >>> a_r_tpl_3 = slowly_recover_from_not_found(
+        ...     art.construct_successes_from_iterable((1, 2))
+        ... )
+        >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_3))
+        ('success', (1, 2))
+    """
+    return map_failure_to_awaitable_result_iterable(
+        compose2((f, construct_from_awaitable_result))
     )
 
 
@@ -683,6 +858,45 @@ def map_successes_to_awaitable(
     """
     return map_successes_to_awaitable_result_iterable(
         compose2((f, construct_successes_from_awaitable))
+    )
+
+
+def map_successes_to_awaitable_iterable(
+    f: Callable[[_S1], Awaitable[Iterable[_S2]]],
+) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S2]]:
+    """Map an awaitable-[collections.abc.Iterable][]-returning function
+    over each element in a [trcks.AwaitableResultTuple][].
+
+    [trcks.AwaitableFailure][] values are left unchanged.
+
+    Args:
+        f: Asynchronous function to apply to each success element.
+
+    Returns:
+        Function that flat-maps [trcks.AwaitableSuccessTuple][] values
+            element-wise using the given asynchronous function.
+
+    Example:
+        >>> import asyncio
+        >>> from trcks.fp.monads import awaitable_result_tuple as art
+        >>> async def _slowly_duplicate_integer(n: int) -> tuple[int, int]:
+        ...     await asyncio.sleep(0.001)
+        ...     return n, n
+        ...
+        >>> slowly_duplicate_integers = art.map_successes_to_awaitable_iterable(
+        ...     _slowly_duplicate_integer
+        ... )
+        >>> a_r_tpl_1 = slowly_duplicate_integers(
+        ...     art.construct_successes_from_iterable((1, 2))
+        ... )
+        >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_1))
+        ('success', (1, 1, 2, 2))
+        >>> a_r_tpl_2 = slowly_duplicate_integers(art.construct_failure("oops"))
+        >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_2))
+        ('failure', 'oops')
+    """
+    return map_successes_to_awaitable_result_iterable(
+        compose2((f, construct_successes_from_awaitable_iterable))
     )
 
 
@@ -1050,6 +1264,64 @@ def tap_failure_to_awaitable(
         return value
 
     return map_failure_to_awaitable(bypassed_f)
+
+
+def tap_failure_to_awaitable_iterable(
+    f: Callable[[_F1], Awaitable[Iterable[object]]],
+) -> Callable[
+    [AwaitableResultTuple[_F1, _S1]],
+    Awaitable[SuccessTuple[_F1] | SuccessTuple[_S1]],
+]:
+    """Apply an asynchronous [collections.abc.Iterable][]-returning side effect
+    to [trcks.AwaitableFailure][] values.
+
+    The number of side effect outputs determines how many times the original
+    failure value is repeated. The failure is converted to a
+    [trcks.AwaitableSuccessTuple][].
+
+    [trcks.AwaitableSuccessTuple][] values are passed on without side effects.
+
+    Args:
+        f: Asynchronous side effect to apply to the [trcks.AwaitableFailure][] value.
+
+    Returns:
+        Applies the given side effect to [trcks.AwaitableFailure][] values and
+            converts them to [trcks.AwaitableSuccessTuple][] values containing
+            the original failure repeated once per element in the
+            [collections.abc.Iterable][] returned by the side effect.
+            Passes on [trcks.AwaitableSuccessTuple][] values without side effects.
+
+    Example:
+        >>> import asyncio
+        >>> from trcks.fp.monads import awaitable_result_tuple as art
+        >>> async def _slowly_log_and_alert(description: str) -> tuple[None, None]:
+        ...     await asyncio.sleep(0.001)
+        ...     return (
+        ...         print(f"Failure: {description}"),
+        ...         print(f"Logged: {description}"),
+        ...     )
+        ...
+        >>> slowly_log_and_alert = art.tap_failure_to_awaitable_iterable(
+        ...     _slowly_log_and_alert
+        ... )
+        >>> a_r_tpl_1 = slowly_log_and_alert(art.construct_failure("critical"))
+        >>> r_tpl_1 = asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_1))
+        Failure: critical
+        Logged: critical
+        >>> r_tpl_1
+        ('success', ('critical', 'critical'))
+        >>> a_r_tpl_2 = slowly_log_and_alert(
+        ...     art.construct_successes_from_iterable((1,))
+        ... )
+        >>> r_tpl_2 = asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_2))
+        >>> r_tpl_2
+        ('success', (1,))
+    """
+
+    async def bypassed_f(value: _F1) -> tuple[_F1, ...]:
+        return tuple(value for _ in await f(value))
+
+    return map_failure_to_awaitable_iterable(bypassed_f)
 
 
 def tap_failure_to_awaitable_result(
@@ -1433,6 +1705,49 @@ def tap_successes_to_awaitable(
         return value
 
     return map_successes_to_awaitable(bypassed_f)
+
+
+def tap_successes_to_awaitable_iterable(
+    f: Callable[[_S1], Awaitable[Iterable[object]]],
+) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S1]]:
+    """Apply an asynchronous [collections.abc.Iterable][]-returning side effect
+    to each element in a [trcks.AwaitableResultTuple][].
+
+    The number of side effect outputs determines how many times each original
+    element is repeated in the resulting tuple.
+
+    [trcks.AwaitableFailure][] values are passed on without side effects.
+
+    Args:
+        f: Asynchronous side effect to apply to each success element.
+
+    Returns:
+        Applies the given side effect and returns a
+            [trcks.AwaitableResultTuple][] where each original success element
+            is repeated once per element returned by the side effect.
+
+    Example:
+        >>> import asyncio
+        >>> from trcks.fp.monads import awaitable_result_tuple as art
+        >>> async def _slowly_log_twice(n: int) -> tuple[None, None]:
+        ...     await asyncio.sleep(0.001)
+        ...     return print(f"Received: {n}"), print(f"Received: {n}")
+        ...
+        >>> slowly_log_twice = art.tap_successes_to_awaitable_iterable(
+        ...     _slowly_log_twice
+        ... )
+        >>> a_r_tpl = slowly_log_twice(art.construct_successes_from_iterable((7,)))
+        >>> r_tpl = asyncio.run(art.to_coroutine_result_tuple(a_r_tpl))
+        Received: 7
+        Received: 7
+        >>> r_tpl
+        ('success', (7, 7))
+    """
+
+    async def bypassed_f(value: _S1) -> tuple[_S1, ...]:
+        return tuple(value for _ in await f(value))
+
+    return map_successes_to_awaitable_iterable(bypassed_f)
 
 
 def tap_successes_to_awaitable_result(

--- a/src/trcks/fp/monads/awaitable_result_tuple.py
+++ b/src/trcks/fp/monads/awaitable_result_tuple.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
         AwaitableResultIterable,
         AwaitableResultTuple,
         AwaitableSuccessTuple,
+        AwaitableTuple,
         Result,
         ResultIterable,
         ResultTuple,
@@ -628,7 +629,7 @@ def map_failure_to_awaitable_result_tuple(
 
 @deprecated("Use map_failure_to_awaitable_iterable instead")
 def map_failure_to_awaitable_tuple(
-    f: Callable[[_F1], Awaitable[tuple[_S2, ...]]],
+    f: Callable[[_F1], AwaitableTuple[_S2]],
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     Awaitable[SuccessTuple[_S1] | SuccessTuple[_S2]],
@@ -1064,7 +1065,7 @@ def map_successes_to_awaitable_result_tuple(
 
 @deprecated("Use map_successes_to_awaitable_iterable instead")
 def map_successes_to_awaitable_tuple(
-    f: Callable[[_S1], Awaitable[tuple[_S2, ...]]],
+    f: Callable[[_S1], AwaitableTuple[_S2]],
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S2]]:
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.map_successes_to_awaitable_iterable][].
@@ -1483,7 +1484,7 @@ def tap_failure_to_awaitable_result_tuple(
 
 @deprecated("Use tap_failure_to_awaitable_iterable instead")
 def tap_failure_to_awaitable_tuple(
-    f: Callable[[_F1], Awaitable[tuple[object, ...]]],
+    f: Callable[[_F1], AwaitableTuple[object]],
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     Awaitable[SuccessTuple[_F1] | SuccessTuple[_S1]],
@@ -1915,7 +1916,7 @@ def tap_successes_to_awaitable_result_tuple(
 
 @deprecated("Use tap_successes_to_awaitable_iterable instead")
 def tap_successes_to_awaitable_tuple(
-    f: Callable[[_S1], Awaitable[tuple[object, ...]]],
+    f: Callable[[_S1], AwaitableTuple[object]],
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S1]]:
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.tap_successes_to_awaitable_iterable][].

--- a/src/trcks/fp/monads/awaitable_tuple.py
+++ b/src/trcks/fp/monads/awaitable_tuple.py
@@ -116,6 +116,31 @@ def construct_from_awaitable(awtbl: Awaitable[_T]) -> AwaitableTuple[_T]:
     return a.map_(t.construct)(awtbl)
 
 
+def construct_from_awaitable_iterable(
+    a_it: AwaitableIterable[_T],
+) -> AwaitableTuple[_T]:
+    """Create a [trcks.AwaitableTuple][] from a [trcks.AwaitableIterable][].
+
+    Args:
+        a_it: The [trcks.AwaitableIterable][] to create
+            the [trcks.AwaitableTuple][] from.
+
+    Returns:
+        The [trcks.AwaitableTuple][] created from the [trcks.AwaitableIterable][].
+
+    Example:
+        >>> import asyncio
+        >>> from trcks import AwaitableIterable, AwaitableTuple
+        >>> from trcks.fp.monads import awaitable as a
+        >>> from trcks.fp.monads import awaitable_tuple as at
+        >>> a_it: AwaitableIterable[int] = a.construct((1, 2))
+        >>> a_tpl: AwaitableTuple[int] = at.construct_from_awaitable_iterable(a_it)
+        >>> asyncio.run(at.to_coroutine_tuple(a_tpl))
+        (1, 2)
+    """
+    return a.map_(tuple)(a_it)
+
+
 def construct_from_iterable(it: Iterable[_T]) -> AwaitableTuple[_T]:
     """Create a [trcks.AwaitableTuple][] from an iterable.
 

--- a/src/trcks/fp/monads/awaitable_tuple.py
+++ b/src/trcks/fp/monads/awaitable_tuple.py
@@ -133,7 +133,7 @@ def construct_from_awaitable_iterable(
         >>> from trcks import AwaitableIterable, AwaitableTuple
         >>> from trcks.fp.monads import awaitable as a
         >>> from trcks.fp.monads import awaitable_tuple as at
-        >>> a_it: AwaitableIterable[int] = a.construct((1, 2))
+        >>> a_it: AwaitableIterable[int] = a.construct([1, 2])
         >>> a_tpl: AwaitableTuple[int] = at.construct_from_awaitable_iterable(a_it)
         >>> asyncio.run(at.to_coroutine_tuple(a_tpl))
         (1, 2)

--- a/src/trcks/fp/monads/result_tuple.py
+++ b/src/trcks/fp/monads/result_tuple.py
@@ -110,7 +110,7 @@ def construct_from_result_iterable(r_it: ResultIterable[_F, _S]) -> ResultTuple[
 
     Example:
         >>> from trcks.fp.monads import result_tuple as rt
-        >>> rt.construct_from_result_iterable(("success", (1, 2)))
+        >>> rt.construct_from_result_iterable(("success", [1, 2]))
         ('success', (1, 2))
         >>> rt.construct_from_result_iterable(("failure", "oops"))
         ('failure', 'oops')

--- a/src/trcks/fp/monads/result_tuple.py
+++ b/src/trcks/fp/monads/result_tuple.py
@@ -97,6 +97,27 @@ def construct_from_result(rslt: Result[_F, _S]) -> ResultTuple[_F, _S]:
     return r.map_success(t.construct)(rslt)
 
 
+def construct_from_result_iterable(r_it: ResultIterable[_F, _S]) -> ResultTuple[_F, _S]:
+    """Create a [trcks.ResultTuple][] object from a [trcks.ResultIterable][].
+
+    Args:
+        r_it: The [trcks.ResultIterable][] object to be converted.
+
+    Returns:
+        A new [trcks.ResultTuple][] instance
+            with the success payload converted to a tuple,
+            or the original failure.
+
+    Example:
+        >>> from trcks.fp.monads import result_tuple as rt
+        >>> rt.construct_from_result_iterable(("success", (1, 2)))
+        ('success', (1, 2))
+        >>> rt.construct_from_result_iterable(("failure", "oops"))
+        ('failure', 'oops')
+    """
+    return r.map_success(tuple)(r_it)
+
+
 def construct_successes(value: _S) -> SuccessTuple[_S]:
     """Create a [trcks.SuccessTuple][] object from a single value.
 

--- a/src/trcks/oop/_awaitable_result_tuple_wrapper.py
+++ b/src/trcks/oop/_awaitable_result_tuple_wrapper.py
@@ -491,7 +491,7 @@ class AwaitableResultTupleWrapper(
         return AwaitableResultTupleWrapper(art.map_failure_to_awaitable(f)(self.core))
 
     def map_failure_to_awaitable_iterable(
-        self, f: Callable[[_F_default_co], Awaitable[Iterable[_S]]]
+        self, f: Callable[[_F_default_co], AwaitableIterable[_S]]
     ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
         """Apply an asynchronous function returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Failure][] object.
@@ -993,7 +993,7 @@ class AwaitableResultTupleWrapper(
         return AwaitableResultTupleWrapper(art.map_successes_to_awaitable(f)(self.core))
 
     def map_successes_to_awaitable_iterable(
-        self, f: Callable[[_S_default_co], Awaitable[Iterable[_S]]]
+        self, f: Callable[[_S_default_co], AwaitableIterable[_S]]
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
         """Apply an asynchronous function returning an [collections.abc.Iterable][]
         to each element in the wrapped [trcks.AwaitableSuccessTuple][] and flatten.
@@ -1454,7 +1454,7 @@ class AwaitableResultTupleWrapper(
         return AwaitableResultTupleWrapper(art.tap_failure_to_awaitable(f)(self.core))
 
     def tap_failure_to_awaitable_iterable(
-        self, f: Callable[[_F_default_co], Awaitable[Iterable[object]]]
+        self, f: Callable[[_F_default_co], AwaitableIterable[object]]
     ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Apply an asynchronous side effect returning an
         [collections.abc.Iterable][] to the wrapped [trcks.Failure][] object.
@@ -1945,7 +1945,7 @@ class AwaitableResultTupleWrapper(
         return AwaitableResultTupleWrapper(art.tap_successes_to_awaitable(f)(self.core))
 
     def tap_successes_to_awaitable_iterable(
-        self, f: Callable[[_S_default_co], Awaitable[Iterable[object]]]
+        self, f: Callable[[_S_default_co], AwaitableIterable[object]]
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply an asynchronous side effect returning an
         [collections.abc.Iterable][] to each element in the wrapped

--- a/src/trcks/oop/_awaitable_result_tuple_wrapper.py
+++ b/src/trcks/oop/_awaitable_result_tuple_wrapper.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
         AwaitableResult,
         AwaitableResultIterable,
         AwaitableResultTuple,
+        AwaitableTuple,
         Result,
         ResultIterable,
     )
@@ -698,6 +699,15 @@ class AwaitableResultTupleWrapper(
         """
         return self.map_failure_to_awaitable_result_iterable(f)  # pragma: no cover
 
+    @deprecated("Use map_failure_to_awaitable_iterable instead")
+    def map_failure_to_awaitable_tuple(
+        self, f: Callable[[_F_default_co], AwaitableTuple[_S]]
+    ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
+        """Deprecated alias for
+        [trcks.oop.AwaitableResultTupleWrapper.map_failure_to_awaitable_iterable][].
+        """
+        return self.map_failure_to_awaitable_iterable(f)  # pragma: no cover
+
     def map_failure_to_iterable(
         self, f: Callable[[_F_default_co], Iterable[_S]]
     ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
@@ -1197,6 +1207,15 @@ class AwaitableResultTupleWrapper(
         """
         return self.map_successes_to_awaitable_result_iterable(f)  # pragma: no cover
 
+    @deprecated("Use map_successes_to_awaitable_iterable instead")
+    def map_successes_to_awaitable_tuple(
+        self, f: Callable[[_S_default_co], AwaitableTuple[_S]]
+    ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
+        """Deprecated alias for
+        [trcks.oop.AwaitableResultTupleWrapper.map_successes_to_awaitable_iterable][].
+        """
+        return self.map_successes_to_awaitable_iterable(f)  # pragma: no cover
+
     def map_successes_to_iterable(
         self, f: Callable[[_S_default_co], Iterable[_S]]
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
@@ -1644,6 +1663,15 @@ class AwaitableResultTupleWrapper(
         [trcks.oop.AwaitableResultTupleWrapper.tap_failure_to_awaitable_result_iterable][].
         """
         return self.tap_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+
+    @deprecated("Use tap_failure_to_awaitable_iterable instead")
+    def tap_failure_to_awaitable_tuple(
+        self, f: Callable[[_F_default_co], AwaitableTuple[object]]
+    ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
+        """Deprecated alias for
+        [trcks.oop.AwaitableResultTupleWrapper.tap_failure_to_awaitable_iterable][].
+        """
+        return self.tap_failure_to_awaitable_iterable(f)  # pragma: no cover
 
     def tap_failure_to_iterable(
         self, f: Callable[[_F_default_co], Iterable[object]]
@@ -2131,6 +2159,15 @@ class AwaitableResultTupleWrapper(
         [trcks.oop.AwaitableResultTupleWrapper.tap_successes_to_awaitable_result_iterable][].
         """
         return self.tap_successes_to_awaitable_result_iterable(f)  # pragma: no cover
+
+    @deprecated("Use tap_successes_to_awaitable_iterable instead")
+    def tap_successes_to_awaitable_tuple(
+        self, f: Callable[[_S_default_co], AwaitableTuple[object]]
+    ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
+        """Deprecated alias for
+        [trcks.oop.AwaitableResultTupleWrapper.tap_successes_to_awaitable_iterable][].
+        """
+        return self.tap_successes_to_awaitable_iterable(f)  # pragma: no cover
 
     def tap_successes_to_iterable(
         self, f: Callable[[_S_default_co], Iterable[object]]

--- a/src/trcks/oop/_awaitable_result_tuple_wrapper.py
+++ b/src/trcks/oop/_awaitable_result_tuple_wrapper.py
@@ -184,7 +184,7 @@ class AwaitableResultTupleWrapper(
             >>> from trcks.oop import AwaitableResultTupleWrapper
             >>> async def slowly_read_from_disk() -> ResultIterable[str, int]:
             ...     await asyncio.sleep(0.001)
-            ...     return "success", (1, 2)
+            ...     return "success", [1, 2]
             ...
             >>> wrapper = (
             ...     AwaitableResultTupleWrapper
@@ -351,7 +351,7 @@ class AwaitableResultTupleWrapper(
             >>> from trcks import AwaitableIterable
             >>> from trcks.fp.monads import awaitable as a
             >>> from trcks.oop import AwaitableResultTupleWrapper
-            >>> a_it: AwaitableIterable[int] = a.construct((1, 2))
+            >>> a_it: AwaitableIterable[int] = a.construct([1, 2])
             >>> wrapper = (
             ...     AwaitableResultTupleWrapper
             ...     .construct_successes_from_awaitable_iterable(a_it)
@@ -514,18 +514,18 @@ class AwaitableResultTupleWrapper(
         Example:
             >>> import asyncio
             >>> from trcks.oop import AwaitableResultTupleWrapper
-            >>> async def _slowly_recover_from_not_found(
+            >>> async def _slowly_recover_from_failure(
             ...     description: str,
-            ... ) -> tuple[int, ...]:
+            ... ) -> list[int]:
             ...     await asyncio.sleep(0.001)
             ...     if description == "not found":
-            ...         return (0,)
-            ...     return ()
+            ...         return [0]
+            ...     return []
             ...
             >>> wrapper_1 = (
             ...     AwaitableResultTupleWrapper
             ...     .construct_failure("not found")
-            ...     .map_failure_to_awaitable_iterable(_slowly_recover_from_not_found)
+            ...     .map_failure_to_awaitable_iterable(_slowly_recover_from_failure)
             ... )
             >>> wrapper_1
             AwaitableResultTupleWrapper(core=<coroutine object ...>)
@@ -535,7 +535,7 @@ class AwaitableResultTupleWrapper(
             >>> wrapper_2 = (
             ...     AwaitableResultTupleWrapper
             ...     .construct_failure("fatal")
-            ...     .map_failure_to_awaitable_iterable(_slowly_recover_from_not_found)
+            ...     .map_failure_to_awaitable_iterable(_slowly_recover_from_failure)
             ... )
             >>> wrapper_2
             AwaitableResultTupleWrapper(core=<coroutine object ...>)
@@ -544,8 +544,8 @@ class AwaitableResultTupleWrapper(
             >>>
             >>> wrapper_3 = (
             ...     AwaitableResultTupleWrapper
-            ...     .construct_successes_from_iterable((1, 2))
-            ...     .map_failure_to_awaitable_iterable(_slowly_recover_from_not_found)
+            ...     .construct_successes_from_iterable([1, 2])
+            ...     .map_failure_to_awaitable_iterable(_slowly_recover_from_failure)
             ... )
             >>> wrapper_3
             AwaitableResultTupleWrapper(core=<coroutine object ...>)
@@ -608,7 +608,7 @@ class AwaitableResultTupleWrapper(
             >>>
             >>> wrapper_3 = (
             ...     AwaitableResultTupleWrapper
-            ...     .construct_successes_from_iterable((1, 2))
+            ...     .construct_successes_from_iterable([1, 2])
             ...     .map_failure_to_awaitable_result(_slowly_recover_from_not_found)
             ... )
             >>> wrapper_3
@@ -1031,7 +1031,7 @@ class AwaitableResultTupleWrapper(
             ...
             >>> wrapper_1 = (
             ...     AwaitableResultTupleWrapper
-            ...     .construct_successes_from_iterable((1, 2))
+            ...     .construct_successes_from_iterable([1, 2])
             ...     .map_successes_to_awaitable_iterable(_slowly_duplicate_integer)
             ... )
             >>> wrapper_1
@@ -2006,7 +2006,7 @@ class AwaitableResultTupleWrapper(
             ...
             >>> wrapper = (
             ...     AwaitableResultTupleWrapper
-            ...     .construct_successes_from_iterable((7,))
+            ...     .construct_successes_from_iterable([7])
             ...     .tap_successes_to_awaitable_iterable(_slowly_log_twice)
             ... )
             >>> wrapper

--- a/src/trcks/oop/_awaitable_result_tuple_wrapper.py
+++ b/src/trcks/oop/_awaitable_result_tuple_wrapper.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable
 
     from trcks import (
+        AwaitableIterable,
         AwaitableResult,
         AwaitableResultIterable,
         AwaitableResultTuple,
@@ -162,6 +163,42 @@ class AwaitableResultTupleWrapper(
         return AwaitableResultTupleWrapper(art.construct_from_awaitable_result(a_rslt))
 
     @staticmethod
+    def construct_from_awaitable_result_iterable(
+        a_r_it: AwaitableResultIterable[_F, _S],
+    ) -> AwaitableResultTupleWrapper[_F, _S]:
+        """Construct and wrap an [trcks.AwaitableResultTuple][] from an
+        [trcks.AwaitableResultIterable][].
+
+        Args:
+            a_r_it: The [trcks.AwaitableResultIterable][] object to be converted.
+
+        Returns:
+            A new [trcks.oop.AwaitableResultTupleWrapper][] instance where
+                the success payload is converted to a tuple,
+                or the original failure is preserved.
+
+        Example:
+            >>> import asyncio
+            >>> from trcks import ResultIterable
+            >>> from trcks.oop import AwaitableResultTupleWrapper
+            >>> async def slowly_read_from_disk() -> ResultIterable[str, int]:
+            ...     await asyncio.sleep(0.001)
+            ...     return "success", (1, 2)
+            ...
+            >>> wrapper = (
+            ...     AwaitableResultTupleWrapper
+            ...     .construct_from_awaitable_result_iterable(slowly_read_from_disk())
+            ... )
+            >>> wrapper
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper.core_as_coroutine)
+            ('success', (1, 2))
+        """
+        return AwaitableResultTupleWrapper(
+            art.construct_from_awaitable_result_iterable(a_r_it)
+        )
+
+    @staticmethod
     def construct_from_result(
         rslt: Result[_F_default, _S_default],
     ) -> AwaitableResultTupleWrapper[_F_default, _S_default]:
@@ -295,6 +332,39 @@ class AwaitableResultTupleWrapper(
         )
 
     @staticmethod
+    def construct_successes_from_awaitable_iterable(
+        a_it: AwaitableIterable[_S],
+    ) -> AwaitableResultTupleWrapper[Never, _S]:
+        """Construct and wrap an awaitable [trcks.SuccessTuple][] from an
+        [trcks.AwaitableIterable][].
+
+        Args:
+            a_it: The [trcks.AwaitableIterable][] object to be wrapped and converted.
+
+        Returns:
+            A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
+                the wrapped [trcks.AwaitableResultTuple][] object.
+
+        Example:
+            >>> import asyncio
+            >>> from trcks import AwaitableIterable
+            >>> from trcks.fp.monads import awaitable as a
+            >>> from trcks.oop import AwaitableResultTupleWrapper
+            >>> a_it: AwaitableIterable[int] = a.construct((1, 2))
+            >>> wrapper = (
+            ...     AwaitableResultTupleWrapper
+            ...     .construct_successes_from_awaitable_iterable(a_it)
+            ... )
+            >>> wrapper
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper.core_as_coroutine)
+            ('success', (1, 2))
+        """
+        return AwaitableResultTupleWrapper(
+            art.construct_successes_from_awaitable_iterable(a_it)
+        )
+
+    @staticmethod
     def construct_successes_from_iterable(
         it: Iterable[_S],
     ) -> AwaitableResultTupleWrapper[Never, _S]:
@@ -419,6 +489,135 @@ class AwaitableResultTupleWrapper(
             ('success', (1, 2))
         """
         return AwaitableResultTupleWrapper(art.map_failure_to_awaitable(f)(self.core))
+
+    def map_failure_to_awaitable_iterable(
+        self, f: Callable[[_F_default_co], Awaitable[Iterable[_S]]]
+    ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
+        """Apply an asynchronous function returning an [collections.abc.Iterable][]
+        to the wrapped [trcks.Failure][] object.
+
+        Wrapped [trcks.SuccessTuple][] objects are passed on unchanged.
+
+        Args:
+            f: The asynchronous function returning an
+                [collections.abc.Iterable][] to be applied.
+
+        Returns:
+            A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
+
+                - an [trcks.AwaitableSuccessTuple][] containing the result of
+                    the function application if
+                    the original [trcks.AwaitableResultTuple][] is a failure, or
+                - the original [trcks.AwaitableResultTuple][] if it is a success.
+
+        Example:
+            >>> import asyncio
+            >>> from trcks.oop import AwaitableResultTupleWrapper
+            >>> async def _slowly_recover_from_not_found(
+            ...     description: str,
+            ... ) -> tuple[int, ...]:
+            ...     await asyncio.sleep(0.001)
+            ...     if description == "not found":
+            ...         return (0,)
+            ...     return ()
+            ...
+            >>> wrapper_1 = (
+            ...     AwaitableResultTupleWrapper
+            ...     .construct_failure("not found")
+            ...     .map_failure_to_awaitable_iterable(_slowly_recover_from_not_found)
+            ... )
+            >>> wrapper_1
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_1.core_as_coroutine)
+            ('success', (0,))
+            >>>
+            >>> wrapper_2 = (
+            ...     AwaitableResultTupleWrapper
+            ...     .construct_failure("fatal")
+            ...     .map_failure_to_awaitable_iterable(_slowly_recover_from_not_found)
+            ... )
+            >>> wrapper_2
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_2.core_as_coroutine)
+            ('success', ())
+            >>>
+            >>> wrapper_3 = (
+            ...     AwaitableResultTupleWrapper
+            ...     .construct_successes_from_iterable((1, 2))
+            ...     .map_failure_to_awaitable_iterable(_slowly_recover_from_not_found)
+            ... )
+            >>> wrapper_3
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_3.core_as_coroutine)
+            ('success', (1, 2))
+        """
+        mapped_f: Callable[
+            [AwaitableResultTuple[_F_default_co, _S_default_co]],
+            AwaitableResultTuple[Never, _S_default_co | _S],
+        ] = art.map_failure_to_awaitable_iterable(f)
+        return AwaitableResultTupleWrapper(mapped_f(self.core))
+
+    def map_failure_to_awaitable_result(
+        self, f: Callable[[_F_default_co], AwaitableResult[_F, _S]]
+    ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
+        """Apply an asynchronous function with return type [trcks.AwaitableResult][]
+        to the wrapped [trcks.Failure][] object.
+
+        Wrapped [trcks.SuccessTuple][] objects are passed on unchanged.
+
+        Args:
+            f: The asynchronous function to be applied.
+
+        Returns:
+            A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
+
+                - the result of the function application if
+                    the original [trcks.AwaitableResultTuple][] is a failure, or
+                - the original [trcks.AwaitableResultTuple][] if it is a success.
+
+        Example:
+            >>> import asyncio
+            >>> from trcks import Result
+            >>> from trcks.oop import AwaitableResultTupleWrapper
+            >>> async def _slowly_recover_from_not_found(e: str) -> Result[str, int]:
+            ...     await asyncio.sleep(0.001)
+            ...     if e == "not found":
+            ...         return "success", 0
+            ...     return "failure", e
+            ...
+            >>> wrapper_1 = (
+            ...     AwaitableResultTupleWrapper
+            ...     .construct_failure("not found")
+            ...     .map_failure_to_awaitable_result(_slowly_recover_from_not_found)
+            ... )
+            >>> wrapper_1
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_1.core_as_coroutine)
+            ('success', (0,))
+            >>>
+            >>> wrapper_2 = (
+            ...     AwaitableResultTupleWrapper
+            ...     .construct_failure("fatal")
+            ...     .map_failure_to_awaitable_result(_slowly_recover_from_not_found)
+            ... )
+            >>> wrapper_2
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_2.core_as_coroutine)
+            ('failure', 'fatal')
+            >>>
+            >>> wrapper_3 = (
+            ...     AwaitableResultTupleWrapper
+            ...     .construct_successes_from_iterable((1, 2))
+            ...     .map_failure_to_awaitable_result(_slowly_recover_from_not_found)
+            ... )
+            >>> wrapper_3
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_3.core_as_coroutine)
+            ('success', (1, 2))
+        """
+        return AwaitableResultTupleWrapper(
+            art.map_failure_to_awaitable_result(f)(self.core)
+        )
 
     def map_failure_to_awaitable_result_iterable(
         self, f: Callable[[_F_default_co], AwaitableResultIterable[_F, _S]]
@@ -792,6 +991,57 @@ class AwaitableResultTupleWrapper(
             ('failure', 'not found')
         """
         return AwaitableResultTupleWrapper(art.map_successes_to_awaitable(f)(self.core))
+
+    def map_successes_to_awaitable_iterable(
+        self, f: Callable[[_S_default_co], Awaitable[Iterable[_S]]]
+    ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
+        """Apply an asynchronous function returning an [collections.abc.Iterable][]
+        to each element in the wrapped [trcks.AwaitableSuccessTuple][] and flatten.
+
+        Wrapped [trcks.Failure][] objects are passed on unchanged.
+
+        Args:
+            f: The asynchronous function returning an
+                [collections.abc.Iterable][] to be applied to each success element.
+
+        Returns:
+            A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
+
+                - the original [trcks.AwaitableResultTuple][] if it is a failure,
+                    or
+                - a flattened [trcks.AwaitableSuccessTuple][] if
+                    the original [trcks.AwaitableResultTuple][] is a success.
+
+        Example:
+            >>> import asyncio
+            >>> from trcks.oop import AwaitableResultTupleWrapper
+            >>> async def _slowly_duplicate_integer(n: int) -> tuple[int, int]:
+            ...     await asyncio.sleep(0.001)
+            ...     return n, n
+            ...
+            >>> wrapper_1 = (
+            ...     AwaitableResultTupleWrapper
+            ...     .construct_successes_from_iterable((1, 2))
+            ...     .map_successes_to_awaitable_iterable(_slowly_duplicate_integer)
+            ... )
+            >>> wrapper_1
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_1.core_as_coroutine)
+            ('success', (1, 1, 2, 2))
+            >>>
+            >>> wrapper_2 = (
+            ...     AwaitableResultTupleWrapper
+            ...     .construct_failure("oops")
+            ...     .map_successes_to_awaitable_iterable(_slowly_duplicate_integer)
+            ... )
+            >>> wrapper_2
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_2.core_as_coroutine)
+            ('failure', 'oops')
+        """
+        return AwaitableResultTupleWrapper(
+            art.map_successes_to_awaitable_iterable(f)(self.core)
+        )
 
     def map_successes_to_awaitable_result(
         self, f: Callable[[_S_default_co], AwaitableResult[_F, _S]]
@@ -1202,6 +1452,73 @@ class AwaitableResultTupleWrapper(
             ('success', (1,))
         """
         return AwaitableResultTupleWrapper(art.tap_failure_to_awaitable(f)(self.core))
+
+    def tap_failure_to_awaitable_iterable(
+        self, f: Callable[[_F_default_co], Awaitable[Iterable[object]]]
+    ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
+        """Apply an asynchronous side effect returning an
+        [collections.abc.Iterable][] to the wrapped [trcks.Failure][] object.
+
+        The failure is converted to an [trcks.AwaitableSuccessTuple][] where
+        the original failure value is repeated once per element in
+        the [collections.abc.Iterable][] returned by the side effect.
+
+        Wrapped [trcks.SuccessTuple][] objects are passed on without side effects.
+
+        Args:
+            f: The asynchronous side effect returning an
+                [collections.abc.Iterable][] to be applied.
+
+        Returns:
+            A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
+
+                - an [trcks.AwaitableSuccessTuple][] containing the original
+                    failure repeated once per element in the tuple returned by
+                    the side effect if the original
+                    [trcks.AwaitableResultTuple][] is a failure, or
+                - the original [trcks.AwaitableSuccessTuple][]
+                    if no side effect was applied.
+
+        Example:
+            >>> import asyncio
+            >>> from trcks.oop import AwaitableResultTupleWrapper
+            >>> async def _slowly_log_and_alert(
+            ...     description: str,
+            ... ) -> tuple[None, None]:
+            ...     await asyncio.sleep(0.001)
+            ...     return (
+            ...         print(f"Failure: {description}"),
+            ...         print(f"Logged: {description}"),
+            ...     )
+            ...
+            >>> wrapper_1 = (
+            ...     AwaitableResultTupleWrapper
+            ...     .construct_failure("critical")
+            ...     .tap_failure_to_awaitable_iterable(_slowly_log_and_alert)
+            ... )
+            >>> wrapper_1
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> result_1 = asyncio.run(wrapper_1.core_as_coroutine)
+            Failure: critical
+            Logged: critical
+            >>> result_1
+            ('success', ('critical', 'critical'))
+            >>>
+            >>> wrapper_2 = (
+            ...     AwaitableResultTupleWrapper
+            ...     .construct_successes_from_iterable((1,))
+            ...     .tap_failure_to_awaitable_iterable(_slowly_log_and_alert)
+            ... )
+            >>> wrapper_2
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_2.core_as_coroutine)
+            ('success', (1,))
+        """
+        tapped_f: Callable[
+            [AwaitableResultTuple[_F_default_co, _S_default_co]],
+            AwaitableResultTuple[Never, _F_default_co | _S_default_co],
+        ] = art.tap_failure_to_awaitable_iterable(f)
+        return AwaitableResultTupleWrapper(tapped_f(self.core))
 
     def tap_failure_to_awaitable_result(
         self, f: Callable[[_F_default_co], AwaitableResult[object, _S]]
@@ -1626,6 +1943,55 @@ class AwaitableResultTupleWrapper(
             ('failure', 'oops')
         """
         return AwaitableResultTupleWrapper(art.tap_successes_to_awaitable(f)(self.core))
+
+    def tap_successes_to_awaitable_iterable(
+        self, f: Callable[[_S_default_co], Awaitable[Iterable[object]]]
+    ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
+        """Apply an asynchronous side effect returning an
+        [collections.abc.Iterable][] to each element in the wrapped
+        [trcks.AwaitableSuccessTuple][].
+
+        The number of side effect outputs determines how many times each
+        original element is repeated in the resulting tuple.
+
+        Wrapped [trcks.Failure][] objects are passed on without side effects.
+
+        Args:
+            f: The asynchronous side effect returning an
+                [collections.abc.Iterable][] to be applied to each success element.
+
+        Returns:
+            A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
+
+                - the original [trcks.AwaitableResultTuple][] if it is a failure,
+                    or
+                - an [trcks.AwaitableSuccessTuple][] where each original success
+                    element is repeated once per element returned by
+                    the side effect.
+
+        Example:
+            >>> import asyncio
+            >>> from trcks.oop import AwaitableResultTupleWrapper
+            >>> async def _slowly_log_twice(n: int) -> tuple[None, None]:
+            ...     await asyncio.sleep(0.001)
+            ...     return print(f"Received: {n}"), print(f"Received: {n}")
+            ...
+            >>> wrapper = (
+            ...     AwaitableResultTupleWrapper
+            ...     .construct_successes_from_iterable((7,))
+            ...     .tap_successes_to_awaitable_iterable(_slowly_log_twice)
+            ... )
+            >>> wrapper
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> result = asyncio.run(wrapper.core_as_coroutine)
+            Received: 7
+            Received: 7
+            >>> result
+            ('success', (7, 7))
+        """
+        return AwaitableResultTupleWrapper(
+            art.tap_successes_to_awaitable_iterable(f)(self.core)
+        )
 
     def tap_successes_to_awaitable_result(
         self, f: Callable[[_S_default_co], AwaitableResult[_F, object]]

--- a/src/trcks/oop/_awaitable_tuple_wrapper.py
+++ b/src/trcks/oop/_awaitable_tuple_wrapper.py
@@ -106,6 +106,40 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
         return AwaitableTupleWrapper(at.construct_from_awaitable(awtbl))
 
     @staticmethod
+    def construct_from_awaitable_iterable(
+        a_it: AwaitableIterable[_T],
+    ) -> AwaitableTupleWrapper[_T]:
+        """Construct and wrap a [trcks.AwaitableTuple][] from an
+        [trcks.AwaitableIterable][].
+
+        Args:
+            a_it: The [trcks.AwaitableIterable][] to be wrapped and converted.
+
+        Returns:
+            A new [trcks.oop.AwaitableTupleWrapper][] instance with
+                the wrapped [trcks.AwaitableTuple][] object.
+
+        Example:
+            >>> import asyncio
+            >>> from trcks import AwaitableIterable
+            >>> from trcks.oop import AwaitableTupleWrapper
+            >>> async def slowly_get_values() -> tuple[int, ...]:
+            ...     await asyncio.sleep(0.001)
+            ...     return (1, 2)
+            ...
+            >>> a_it: AwaitableIterable[int] = slowly_get_values()
+            >>> awaitable_tuple_wrapper = (
+            ...     AwaitableTupleWrapper
+            ...     .construct_from_awaitable_iterable(a_it)
+            ... )
+            >>> awaitable_tuple_wrapper
+            AwaitableTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(awaitable_tuple_wrapper.core_as_coroutine)
+            (1, 2)
+        """
+        return AwaitableTupleWrapper(at.construct_from_awaitable_iterable(a_it))
+
+    @staticmethod
     def construct_from_iterable(it: Iterable[_T]) -> AwaitableTupleWrapper[_T]:
         """Construct and wrap a [trcks.AwaitableTuple][] from an iterable.
 

--- a/src/trcks/oop/_awaitable_tuple_wrapper.py
+++ b/src/trcks/oop/_awaitable_tuple_wrapper.py
@@ -123,14 +123,13 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
             >>> import asyncio
             >>> from trcks import AwaitableIterable
             >>> from trcks.oop import AwaitableTupleWrapper
-            >>> async def slowly_get_values() -> tuple[int, ...]:
+            >>> async def slowly_get_values() -> list[int]:
             ...     await asyncio.sleep(0.001)
-            ...     return (1, 2)
+            ...     return [1, 2]
             ...
-            >>> a_it: AwaitableIterable[int] = slowly_get_values()
             >>> awaitable_tuple_wrapper = (
             ...     AwaitableTupleWrapper
-            ...     .construct_from_awaitable_iterable(a_it)
+            ...     .construct_from_awaitable_iterable(slowly_get_values())
             ... )
             >>> awaitable_tuple_wrapper
             AwaitableTupleWrapper(core=<coroutine object ...>)

--- a/src/trcks/oop/_result_tuple_wrapper.py
+++ b/src/trcks/oop/_result_tuple_wrapper.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
         AwaitableResult,
         AwaitableResultIterable,
         AwaitableResultTuple,
+        AwaitableTuple,
         Result,
         ResultIterable,
     )
@@ -428,6 +429,15 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return self.map_failure_to_awaitable_result_iterable(f)  # pragma: no cover
 
+    @deprecated("Use map_failure_to_awaitable_iterable instead")
+    def map_failure_to_awaitable_tuple(
+        self, f: Callable[[_F_default_co], AwaitableTuple[_S]]
+    ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
+        """Deprecated alias for
+        [trcks.oop.ResultTupleWrapper.map_failure_to_awaitable_iterable][].
+        """
+        return self.map_failure_to_awaitable_iterable(f)  # pragma: no cover
+
     def map_failure_to_iterable(
         self, f: Callable[[_F_default_co], Iterable[_S]]
     ) -> ResultTupleWrapper[Never, _S_default_co | _S]:
@@ -822,6 +832,15 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         [trcks.oop.ResultTupleWrapper.map_successes_to_awaitable_result_iterable][].
         """
         return self.map_successes_to_awaitable_result_iterable(f)  # pragma: no cover
+
+    @deprecated("Use map_successes_to_awaitable_iterable instead")
+    def map_successes_to_awaitable_tuple(
+        self, f: Callable[[_S_default_co], AwaitableTuple[_S]]
+    ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
+        """Deprecated alias for
+        [trcks.oop.ResultTupleWrapper.map_successes_to_awaitable_iterable][].
+        """
+        return self.map_successes_to_awaitable_iterable(f)  # pragma: no cover
 
     def map_successes_to_iterable(
         self, f: Callable[[_S_default_co], Iterable[_S]]
@@ -1229,6 +1248,15 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         [trcks.oop.ResultTupleWrapper.tap_failure_to_awaitable_result_iterable][].
         """
         return self.tap_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+
+    @deprecated("Use tap_failure_to_awaitable_iterable instead")
+    def tap_failure_to_awaitable_tuple(
+        self, f: Callable[[_F_default_co], AwaitableTuple[object]]
+    ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
+        """Deprecated alias for
+        [trcks.oop.ResultTupleWrapper.tap_failure_to_awaitable_iterable][].
+        """
+        return self.tap_failure_to_awaitable_iterable(f)  # pragma: no cover
 
     def tap_failure_to_iterable(
         self, f: Callable[[_F_default_co], Iterable[object]]
@@ -1639,6 +1667,15 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         [trcks.oop.ResultTupleWrapper.tap_successes_to_awaitable_result_iterable][].
         """
         return self.tap_successes_to_awaitable_result_iterable(f)  # pragma: no cover
+
+    @deprecated("Use tap_successes_to_awaitable_iterable instead")
+    def tap_successes_to_awaitable_tuple(
+        self, f: Callable[[_S_default_co], AwaitableTuple[object]]
+    ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
+        """Deprecated alias for
+        [trcks.oop.ResultTupleWrapper.tap_successes_to_awaitable_iterable][].
+        """
+        return self.tap_successes_to_awaitable_iterable(f)  # pragma: no cover
 
     def tap_successes_to_iterable(
         self, f: Callable[[_S_default_co], Iterable[object]]

--- a/src/trcks/oop/_result_tuple_wrapper.py
+++ b/src/trcks/oop/_result_tuple_wrapper.py
@@ -128,7 +128,7 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         Example:
             >>> from trcks.oop import ResultTupleWrapper
             >>> ResultTupleWrapper.construct_from_result_iterable(
-            ...     ("success", (1, 2))
+            ...     ("success", [1, 2])
             ... )
             ResultTupleWrapper(core=('success', (1, 2)))
             >>> ResultTupleWrapper.construct_from_result_iterable(
@@ -286,25 +286,25 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         Example:
             >>> import asyncio
             >>> from trcks.oop import ResultTupleWrapper
-            >>> async def _slowly_recover_from_not_found(
+            >>> async def _slowly_recover_from_failure(
             ...     description: str,
-            ... ) -> tuple[int, ...]:
+            ... ) -> list[int]:
             ...     await asyncio.sleep(0.001)
             ...     if description == "not found":
-            ...         return (0,)
-            ...     return ()
+            ...         return [0]
+            ...     return []
             ...
             >>> wrapper_1 = ResultTupleWrapper.construct_failure(
             ...     "not found"
-            ... ).map_failure_to_awaitable_iterable(_slowly_recover_from_not_found)
+            ... ).map_failure_to_awaitable_iterable(_slowly_recover_from_failure)
             >>> wrapper_1
             AwaitableResultTupleWrapper(core=<coroutine object ...>)
             >>> asyncio.run(wrapper_1.core_as_coroutine)
             ('success', (0,))
             >>>
             >>> wrapper_2 = ResultTupleWrapper.construct_successes_from_iterable(
-            ...     (1, 2)
-            ... ).map_failure_to_awaitable_iterable(_slowly_recover_from_not_found)
+            ...     [1, 2]
+            ... ).map_failure_to_awaitable_iterable(_slowly_recover_from_failure)
             >>> wrapper_2
             AwaitableResultTupleWrapper(core=<coroutine object ...>)
             >>> asyncio.run(wrapper_2.core_as_coroutine)
@@ -359,7 +359,7 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
             ('failure', 'fatal')
             >>>
             >>> wrapper_3 = ResultTupleWrapper.construct_successes_from_iterable(
-            ...     (1, 2)
+            ...     [1, 2]
             ... ).map_failure_to_awaitable_result(_slowly_recover_from_not_found)
             >>> wrapper_3
             AwaitableResultTupleWrapper(core=<coroutine object ...>)
@@ -1540,7 +1540,7 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
             ...     return print(f"Received: {n}"), print(f"Received: {n}")
             ...
             >>> wrapper = ResultTupleWrapper.construct_successes_from_iterable(
-            ...     (7,)
+            ...     [7]
             ... ).tap_successes_to_awaitable_iterable(_slowly_log_twice)
             >>> wrapper
             AwaitableResultTupleWrapper(core=<coroutine object ...>)

--- a/src/trcks/oop/_result_tuple_wrapper.py
+++ b/src/trcks/oop/_result_tuple_wrapper.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable
 
     from trcks import (
+        AwaitableIterable,
         AwaitableResult,
         AwaitableResultIterable,
         AwaitableResultTuple,
@@ -262,7 +263,7 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         ).map_failure_to_awaitable(f)
 
     def map_failure_to_awaitable_iterable(
-        self, f: Callable[[_F_default_co], Awaitable[Iterable[_S]]]
+        self, f: Callable[[_F_default_co], AwaitableIterable[_S]]
     ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
         """Apply an asynchronous function returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Failure][] object.
@@ -667,7 +668,7 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         ).map_successes_to_awaitable(f)
 
     def map_successes_to_awaitable_iterable(
-        self, f: Callable[[_S_default_co], Awaitable[Iterable[_S]]]
+        self, f: Callable[[_S_default_co], AwaitableIterable[_S]]
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
         """Apply an asynchronous function returning an [collections.abc.Iterable][]
         to each element in the wrapped [trcks.SuccessTuple][] and flatten.
@@ -1053,7 +1054,7 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         ).tap_failure_to_awaitable(f)
 
     def tap_failure_to_awaitable_iterable(
-        self, f: Callable[[_F_default_co], Awaitable[Iterable[object]]]
+        self, f: Callable[[_F_default_co], AwaitableIterable[object]]
     ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Apply an asynchronous side effect returning an
         [collections.abc.Iterable][] to the wrapped [trcks.Failure][] object.
@@ -1480,7 +1481,7 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         ).tap_successes_to_awaitable(f)
 
     def tap_successes_to_awaitable_iterable(
-        self, f: Callable[[_S_default_co], Awaitable[Iterable[object]]]
+        self, f: Callable[[_S_default_co], AwaitableIterable[object]]
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply an asynchronous side effect returning an
         [collections.abc.Iterable][] to each element in the wrapped

--- a/src/trcks/oop/_result_tuple_wrapper.py
+++ b/src/trcks/oop/_result_tuple_wrapper.py
@@ -110,6 +110,33 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         return ResultTupleWrapper(rt.construct_from_result(rslt))
 
     @staticmethod
+    def construct_from_result_iterable(
+        r_it: ResultIterable[_F_default, _S_default],
+    ) -> ResultTupleWrapper[_F_default, _S_default]:
+        """Construct and wrap a [trcks.ResultTuple][] object from a
+        [trcks.ResultIterable][] object.
+
+        Args:
+            r_it: The [trcks.ResultIterable][] object to be wrapped and converted.
+
+        Returns:
+            A new [trcks.oop.ResultTupleWrapper][] instance with
+                the wrapped [trcks.ResultTuple][] object.
+
+        Example:
+            >>> from trcks.oop import ResultTupleWrapper
+            >>> ResultTupleWrapper.construct_from_result_iterable(
+            ...     ("success", (1, 2))
+            ... )
+            ResultTupleWrapper(core=('success', (1, 2)))
+            >>> ResultTupleWrapper.construct_from_result_iterable(
+            ...     ("failure", "oops")
+            ... )
+            ResultTupleWrapper(core=('failure', 'oops'))
+        """
+        return ResultTupleWrapper(rt.construct_from_result_iterable(r_it))
+
+    @staticmethod
     def construct_successes(value: _S) -> ResultTupleWrapper[Never, _S]:
         """Construct and wrap a [trcks.SuccessTuple][] object from a value.
 
@@ -233,6 +260,113 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
         ).map_failure_to_awaitable(f)
+
+    def map_failure_to_awaitable_iterable(
+        self, f: Callable[[_F_default_co], Awaitable[Iterable[_S]]]
+    ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
+        """Apply an asynchronous function returning an [collections.abc.Iterable][]
+        to the wrapped [trcks.Failure][] object.
+
+        Wrapped [trcks.SuccessTuple][] objects are passed on unchanged.
+
+        Args:
+            f: The asynchronous function returning an
+                [collections.abc.Iterable][] to be applied.
+
+        Returns:
+            A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
+
+                - an [trcks.AwaitableSuccessTuple][] containing the result of
+                    the function application if
+                    the original [trcks.ResultTuple][] is a failure, or
+                - the original [trcks.ResultTuple][] if it is a success.
+
+        Example:
+            >>> import asyncio
+            >>> from trcks.oop import ResultTupleWrapper
+            >>> async def _slowly_recover_from_not_found(
+            ...     description: str,
+            ... ) -> tuple[int, ...]:
+            ...     await asyncio.sleep(0.001)
+            ...     if description == "not found":
+            ...         return (0,)
+            ...     return ()
+            ...
+            >>> wrapper_1 = ResultTupleWrapper.construct_failure(
+            ...     "not found"
+            ... ).map_failure_to_awaitable_iterable(_slowly_recover_from_not_found)
+            >>> wrapper_1
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_1.core_as_coroutine)
+            ('success', (0,))
+            >>>
+            >>> wrapper_2 = ResultTupleWrapper.construct_successes_from_iterable(
+            ...     (1, 2)
+            ... ).map_failure_to_awaitable_iterable(_slowly_recover_from_not_found)
+            >>> wrapper_2
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_2.core_as_coroutine)
+            ('success', (1, 2))
+        """
+        return AwaitableResultTupleWrapper.construct_from_result_iterable(
+            self.core
+        ).map_failure_to_awaitable_iterable(f)
+
+    def map_failure_to_awaitable_result(
+        self, f: Callable[[_F_default_co], AwaitableResult[_F, _S]]
+    ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
+        """Apply an asynchronous function with return type [trcks.AwaitableResult][]
+        to the wrapped [trcks.Failure][] object.
+
+        Wrapped [trcks.SuccessTuple][] objects are passed on unchanged.
+
+        Args:
+            f: The asynchronous function to be applied.
+
+        Returns:
+            A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
+
+                - the result of the function application if
+                    the original [trcks.ResultTuple][] is a failure, or
+                - the original [trcks.ResultTuple][] if it is a success.
+
+        Example:
+            >>> import asyncio
+            >>> from trcks import Result
+            >>> from trcks.oop import ResultTupleWrapper
+            >>> async def _slowly_recover_from_not_found(e: str) -> Result[str, int]:
+            ...     await asyncio.sleep(0.001)
+            ...     if e == "not found":
+            ...         return "success", 0
+            ...     return "failure", e
+            ...
+            >>> wrapper_1 = ResultTupleWrapper.construct_failure(
+            ...     "not found"
+            ... ).map_failure_to_awaitable_result(_slowly_recover_from_not_found)
+            >>> wrapper_1
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_1.core_as_coroutine)
+            ('success', (0,))
+            >>>
+            >>> wrapper_2 = ResultTupleWrapper.construct_failure(
+            ...     "fatal"
+            ... ).map_failure_to_awaitable_result(_slowly_recover_from_not_found)
+            >>> wrapper_2
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_2.core_as_coroutine)
+            ('failure', 'fatal')
+            >>>
+            >>> wrapper_3 = ResultTupleWrapper.construct_successes_from_iterable(
+            ...     (1, 2)
+            ... ).map_failure_to_awaitable_result(_slowly_recover_from_not_found)
+            >>> wrapper_3
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_3.core_as_coroutine)
+            ('success', (1, 2))
+        """
+        return AwaitableResultTupleWrapper.construct_from_result_iterable(
+            self.core
+        ).map_failure_to_awaitable_result(f)
 
     def map_failure_to_awaitable_result_iterable(
         self, f: Callable[[_F_default_co], AwaitableResultIterable[_F, _S]]
@@ -531,6 +665,52 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
         ).map_successes_to_awaitable(f)
+
+    def map_successes_to_awaitable_iterable(
+        self, f: Callable[[_S_default_co], Awaitable[Iterable[_S]]]
+    ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
+        """Apply an asynchronous function returning an [collections.abc.Iterable][]
+        to each element in the wrapped [trcks.SuccessTuple][] and flatten.
+
+        Wrapped [trcks.Failure][] objects are passed on unchanged.
+
+        Args:
+            f: The asynchronous function returning an
+                [collections.abc.Iterable][] to be applied to each success element.
+
+        Returns:
+            A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
+
+                - the original [trcks.ResultTuple][] if it is a failure, or
+                - a flattened awaitable [trcks.SuccessTuple][] if
+                    the original [trcks.ResultTuple][] is a success.
+
+        Example:
+            >>> import asyncio
+            >>> from trcks.oop import ResultTupleWrapper
+            >>> async def _slowly_duplicate_integer(n: int) -> tuple[int, int]:
+            ...     await asyncio.sleep(0.001)
+            ...     return n, n
+            ...
+            >>> wrapper_1 = ResultTupleWrapper.construct_successes_from_iterable(
+            ...     (1, 2)
+            ... ).map_successes_to_awaitable_iterable(_slowly_duplicate_integer)
+            >>> wrapper_1
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_1.core_as_coroutine)
+            ('success', (1, 1, 2, 2))
+            >>>
+            >>> wrapper_2 = ResultTupleWrapper.construct_failure(
+            ...     "oops"
+            ... ).map_successes_to_awaitable_iterable(_slowly_duplicate_integer)
+            >>> wrapper_2
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_2.core_as_coroutine)
+            ('failure', 'oops')
+        """
+        return AwaitableResultTupleWrapper.construct_from_result_iterable(
+            self.core
+        ).map_successes_to_awaitable_iterable(f)
 
     def map_successes_to_awaitable_result(
         self, f: Callable[[_S_default_co], AwaitableResult[_F, _S]]
@@ -871,6 +1051,67 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
         ).tap_failure_to_awaitable(f)
+
+    def tap_failure_to_awaitable_iterable(
+        self, f: Callable[[_F_default_co], Awaitable[Iterable[object]]]
+    ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
+        """Apply an asynchronous side effect returning an
+        [collections.abc.Iterable][] to the wrapped [trcks.Failure][] object.
+
+        The failure is converted to an [trcks.AwaitableSuccessTuple][] where
+        the original failure value is repeated once per element in
+        the [collections.abc.Iterable][] returned by the side effect.
+
+        Wrapped [trcks.SuccessTuple][] objects are passed on without side effects.
+
+        Args:
+            f: The asynchronous side effect returning an
+                [collections.abc.Iterable][] to be applied.
+
+        Returns:
+            A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
+
+                - an [trcks.AwaitableSuccessTuple][] containing the original
+                    failure repeated once per element in the tuple returned by
+                    the side effect if the original [trcks.ResultTuple][] is
+                    a failure, or
+                - the original [trcks.AwaitableSuccessTuple][]
+                    if no side effect was applied.
+
+        Example:
+            >>> import asyncio
+            >>> from trcks.oop import ResultTupleWrapper
+            >>> async def _slowly_log_and_alert(
+            ...     description: str,
+            ... ) -> tuple[None, None]:
+            ...     await asyncio.sleep(0.001)
+            ...     return (
+            ...         print(f"Failure: {description}"),
+            ...         print(f"Logged: {description}"),
+            ...     )
+            ...
+            >>> wrapper_1 = ResultTupleWrapper.construct_failure(
+            ...     "critical"
+            ... ).tap_failure_to_awaitable_iterable(_slowly_log_and_alert)
+            >>> wrapper_1
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> result_1 = asyncio.run(wrapper_1.core_as_coroutine)
+            Failure: critical
+            Logged: critical
+            >>> result_1
+            ('success', ('critical', 'critical'))
+            >>>
+            >>> wrapper_2 = ResultTupleWrapper.construct_successes_from_iterable(
+            ...     (1, 2)
+            ... ).tap_failure_to_awaitable_iterable(_slowly_log_and_alert)
+            >>> wrapper_2
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> asyncio.run(wrapper_2.core_as_coroutine)
+            ('success', (1, 2))
+        """
+        return AwaitableResultTupleWrapper.construct_from_result_iterable(
+            self.core
+        ).tap_failure_to_awaitable_iterable(f)
 
     def tap_failure_to_awaitable_result(
         self, f: Callable[[_F_default_co], AwaitableResult[object, _S]]
@@ -1237,6 +1478,52 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
         ).tap_successes_to_awaitable(f)
+
+    def tap_successes_to_awaitable_iterable(
+        self, f: Callable[[_S_default_co], Awaitable[Iterable[object]]]
+    ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
+        """Apply an asynchronous side effect returning an
+        [collections.abc.Iterable][] to each element in the wrapped
+        [trcks.SuccessTuple][].
+
+        The number of side effect outputs determines how many times each
+        original element is repeated in the resulting tuple.
+
+        Wrapped [trcks.Failure][] objects are passed on without side effects.
+
+        Args:
+            f: The asynchronous side effect returning an
+                [collections.abc.Iterable][] to be applied to each success element.
+
+        Returns:
+            A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
+
+                - the original [trcks.ResultTuple][] if it is a failure, or
+                - an [trcks.AwaitableSuccessTuple][] where each original success
+                    element is repeated once per element returned by
+                    the side effect.
+
+        Example:
+            >>> import asyncio
+            >>> from trcks.oop import ResultTupleWrapper
+            >>> async def _slowly_log_twice(n: int) -> tuple[None, None]:
+            ...     await asyncio.sleep(0.001)
+            ...     return print(f"Received: {n}"), print(f"Received: {n}")
+            ...
+            >>> wrapper = ResultTupleWrapper.construct_successes_from_iterable(
+            ...     (7,)
+            ... ).tap_successes_to_awaitable_iterable(_slowly_log_twice)
+            >>> wrapper
+            AwaitableResultTupleWrapper(core=<coroutine object ...>)
+            >>> result = asyncio.run(wrapper.core_as_coroutine)
+            Received: 7
+            Received: 7
+            >>> result
+            ('success', (7, 7))
+        """
+        return AwaitableResultTupleWrapper.construct_from_result_iterable(
+            self.core
+        ).tap_successes_to_awaitable_iterable(f)
 
     def tap_successes_to_awaitable_result(
         self, f: Callable[[_S_default_co], AwaitableResult[_F, object]]


### PR DESCRIPTION
- fp.monads.result_tuple: add construct_from_result_iterable
- fp.monads.awaitable_tuple: add construct_from_awaitable_iterable
- fp.monads.awaitable_result_tuple: add construct_from_awaitable_result_iterable, construct_successes_from_awaitable_iterable, map_failure_to_awaitable_iterable, map_failure_to_awaitable_result, map_successes_to_awaitable_iterable, tap_failure_to_awaitable_iterable, tap_successes_to_awaitable_iterable
- fp.monads.awaitable_result_tuple: add deprecated aliases map_failure_to_awaitable_tuple, map_successes_to_awaitable_tuple, tap_failure_to_awaitable_tuple, tap_successes_to_awaitable_tuple
- fp.monads.awaitable_result_tuple: refactor construct_from_result_iterable and construct_from_awaitable_result_iterable to reuse result_tuple.construct_from_result_iterable
- oop.AwaitableResultTupleWrapper, oop.ResultTupleWrapper, oop.AwaitableTupleWrapper: mirror the new FP functions (and deprecated aliases) with equivalent wrapper methods