### PR TITLE
Align import-linter documentation with trcks-example-fastapi

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,22 +39,34 @@
   `trcks.AwaitableResult`, `trcks.AwaitableTuple`, `trcks.ResultTuple`, and
   `trcks.AwaitableResultTuple` values.
 
-### Module layers and import rules
+### Application layers
+
+- `trcks` has three layers: `oop`, `fp`, and `_typing`.
+- `trcks.fp` has two layers: `monads` and `composition`.
+- `trcks.fp.monads` has eight layers: `awaitable_result_tuple`,
+  `awaitable_result`, `awaitable_tuple`, `result_tuple`, `awaitable`,
+  `result`, `tuple_`, and `identity`.
+  - Simple monads (i.e. `awaitable`, `result`, `tuple_`)
+    are independent of each other.
+  - Dual monads (i.e. `awaitable_result`, `awaitable_tuple`, `result_tuple`)
+    are independent of each other.
+
+### Import contracts
 
 These constraints are configured in [pyproject.toml](pyproject.toml) and
-enforced by `import-linter`:
+enforced by `import-linter`. `tool.importlinter.contracts` must contain
+at least:
 
-- Layers (highest to lowest;
-  higher layers may import lower layers, but not the reverse):
-  - `trcks`: `oop`, `fp`, and `_typing`.
-  - `trcks.fp`: `monads` and `composition`.
-  - `trcks.fp.monads`: `awaitable_result_tuple`, `awaitable_result`,
-    `awaitable_tuple`, `result_tuple`, `awaitable`, `result`, `tuple_`,
-    and `identity`.
-- Simple monads (i.e. `awaitable`, `result`, `tuple_`) are independent of each other.
-- Dual monads (i.e. `awaitable_result`, `awaitable_tuple`, `result_tuple`)
-  are independent of each other.
-- Only `trcks._typing` imports `typing_extensions`.
+- `layers` contracts that restrict each layer (see "Application layers"
+  above) to importing only the layers below it, for `trcks`, `trcks.fp`,
+  and `trcks.fp.monads`.
+- `independence` contracts that keep simple monads independent of each
+  other and dual monads independent of each other.
+- `protected` contracts that restrict which internal modules may import
+  specific external packages
+  (e.g. only `trcks._typing` imports `typing_extensions`).
+- `acyclic_siblings` contracts that forbid dependency cycles between
+  sibling modules within `trcks`.
 
 ## Code style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,13 @@
 
 ## Architecture decisions
 
+### Application layers
+
+- `trcks` has three layers: `oop`, `fp`, and `_typing`.
+- `trcks.fp` has two sublayers: `monads` and `composition`.
+- `trcks.fp.monads` has eight sublayers: `awaitable_result_tuple`, `awaitable_result`,
+  `awaitable_tuple`, `result_tuple`, `awaitable`, `result`, `tuple_`, and `identity`.
+
 ### Return types defined in `trcks`
 
 - `trcks.Result[FailureType, SuccessType]`:
@@ -39,34 +46,16 @@
   `trcks.AwaitableResult`, `trcks.AwaitableTuple`, `trcks.ResultTuple`, and
   `trcks.AwaitableResultTuple` values.
 
-### Application layers
-
-- `trcks` has three layers: `oop`, `fp`, and `_typing`.
-- `trcks.fp` has two layers: `monads` and `composition`.
-- `trcks.fp.monads` has eight layers: `awaitable_result_tuple`,
-  `awaitable_result`, `awaitable_tuple`, `result_tuple`, `awaitable`,
-  `result`, `tuple_`, and `identity`.
-  - Simple monads (i.e. `awaitable`, `result`, `tuple_`)
-    are independent of each other.
-  - Dual monads (i.e. `awaitable_result`, `awaitable_tuple`, `result_tuple`)
-    are independent of each other.
-
 ### Import contracts
 
-These constraints are configured in [pyproject.toml](pyproject.toml) and
-enforced by `import-linter`. `tool.importlinter.contracts` must contain
-at least:
+`tool.importlinter.contracts` in [pyproject.toml](pyproject.toml) must contain at least:
 
-- `layers` contracts that restrict each layer (see "Application layers"
-  above) to importing only the layers below it, for `trcks`, `trcks.fp`,
-  and `trcks.fp.monads`.
-- `independence` contracts that keep simple monads independent of each
-  other and dual monads independent of each other.
-- `protected` contracts that restrict which internal modules may import
-  specific external packages
-  (e.g. only `trcks._typing` imports `typing_extensions`).
-- `acyclic_siblings` contracts that forbid dependency cycles between
-  sibling modules within `trcks`.
+- `layers` contracts that restrict each layer to importing only
+  the layers below it.
+- `independence` contracts that keep
+  simple monads independent of each other and
+  dual monads independent of each other.
+- `protected` contract that restricts which internal modules may import `typing_extensions`.
 
 ## Code style
 


### PR DESCRIPTION
## Summary

Aligns the import-linter documentation in `AGENTS.md` with the structure and
framing used in `trcks-example-fastapi/AGENTS.md`.

## Changes

- Add a new **"Application layers"** section under "Architecture decisions"
  that documents the layer structure of `trcks`, `trcks.fp`, and
  `trcks.fp.monads` in plain prose, independent of import-linter mechanics
  (including the fact that simple monads and dual monads are each
  independent of one another).
- Rename **"Module layers and import rules"** to **"Import contracts"** and
  rewrite it to describe the actual `import-linter` contract *types*
  configured in `tool.importlinter.contracts` in `pyproject.toml`:
  - `layers`
  - `independence`
  - `protected`
  - `acyclic_siblings`

This mirrors the pattern in `trcks-example-fastapi/AGENTS.md`, where
architecture/layer structure and import-linter contract enforcement are
documented as two separate, decoupled sections.

## Motivation

Keeps documentation conventions consistent across the `trcks` ecosystem and
makes it easier for AI coding agents (and humans) to cross-reference the two
`AGENTS.md` files.