### PR TITLE
Forward extra arguments through map* and tap* helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ in the following example.
 2. The class `trcks.oop.Wrapper` provides a convenient way to chain
    `trcks.Result`-returning functions and "regular" functions
    (in a type-safe way).
-3. See the
+3. The `map*` and `tap*` methods of `trcks.oop.Wrapper` (and the other
+   wrapper classes) accept extra positional and keyword arguments,
+   which are forwarded to the given function.
+4. See the
    [OOP and FP equivalence table](https://christophgietl.github.io/trcks/usage/oop-and-fp-equivalence/)
    for a side-by-side comparison with the functional style,
    and the [glossary](https://christophgietl.github.io/trcks/glossary/)
@@ -151,7 +154,10 @@ in the following example.
    provide a convenient way to chain
    `trcks.Result`-returning functions and "regular" functions
    (in a type-safe way).
-3. See the
+3. The `map*` and `tap*` functions in the modules under `trcks.fp.monads`
+   accept extra positional and keyword arguments,
+   which are forwarded to the given function.
+4. See the
    [OOP and FP equivalence table](https://christophgietl.github.io/trcks/usage/oop-and-fp-equivalence/)
    for a side-by-side comparison with the object-oriented style,
    and the [glossary](https://christophgietl.github.io/trcks/glossary/)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -40,6 +40,9 @@ For example, [trcks.oop.ResultWrapper.map_success][] and
 [trcks.fp.monads.result.map_success][] both apply a function to the success
 value of a [trcks.Result][], leaving failures unchanged.
 These helpers live in `trcks.oop` classes and in the modules under `trcks.fp.monads`.
+Mapping and `tap` helpers also forward any extra positional and keyword
+arguments to the given function, so a lambda or `functools.partial` is not
+needed just to bind an extra argument.
 
 ## Pipeline and `pipe`
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -25,14 +25,14 @@ the other carries information about failures.
 
 A function that accepts a function as an argument,
 returns a function, or both.
-The `map_*` helpers in `trcks` are higher-order functions.
+The `map*` helpers in `trcks` are higher-order functions.
 
 ## Homogeneous tuple
 
 A `tuple[T, ...]` whose elements all share the same type,
 processed individually by `trcks`.
 
-## Mapping helper (or `map_*` function)
+## Mapping helper (or `map*` function)
 
 A helper that lifts a plain function so that it operates on a
 wrapped value ([trcks.oop][]) or becomes a pipeline step ([trcks.fp][]).
@@ -56,7 +56,7 @@ for a full introduction.
 
 ## Short-circuiting
 
-Once a step produces a failure, all subsequent `map_*` steps
+Once a step produces a failure, all subsequent `map*` steps
 are skipped and the failure is carried through to the end of the
 pipeline without further processing.
 
@@ -76,5 +76,5 @@ for definitions and examples.
 
 A side effect is an operation (such as logging or file I/O) that does
 not change the value flowing through the pipeline.
-The `tap_*` helpers run a side effect and then return the original
+The `tap*` helpers run a side effect and then return the original
 value unchanged, keeping the pipeline intact.

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,11 @@ in the following example.
     2. <!-- rumdl-disable-line MD032 --> The class `trcks.oop.Wrapper` provides
        a convenient way to chain `trcks.Result`-returning functions and
        "regular" functions (in a type-safe way).
-    3. <!-- rumdl-disable-line MD032 --> See the
+    3. <!-- rumdl-disable-line MD032 --> The `map*` and `tap*` methods of
+       `trcks.oop.Wrapper` (and the other wrapper classes) accept extra
+       positional and keyword arguments, which are forwarded to the given
+       function.
+    4. <!-- rumdl-disable-line MD032 --> See the
        [OOP and FP equivalence table](usage/oop-and-fp-equivalence.md)
        for a side-by-side comparison with the functional style,
        and the [glossary](glossary.md) for definitions of key terms.
@@ -147,7 +151,10 @@ in the following example.
        `trcks.fp.monads.result` provide a convenient way to chain
        `trcks.Result`-returning functions and "regular" functions
        (in a type-safe way).
-    3. <!-- rumdl-disable-line MD032 --> See the
+    3. <!-- rumdl-disable-line MD032 --> The `map*` and `tap*` functions in
+       the modules under `trcks.fp.monads` accept extra positional and
+       keyword arguments, which are forwarded to the given function.
+    4. <!-- rumdl-disable-line MD032 --> See the
        [OOP and FP equivalence table](usage/oop-and-fp-equivalence.md)
        for a side-by-side comparison with the object-oriented style,
        and the [glossary](glossary.md) for definitions of key terms.

--- a/docs/usage/fp/async.md
+++ b/docs/usage/fp/async.md
@@ -13,7 +13,7 @@ as its input.
 However, functions with input type `collections.abc.Awaitable[T]`
 tend to contain unnecessary `await` statements.
 Therefore, the module [trcks.fp.monads.awaitable][] provides
-some higher-order functions named `map_*`
+some higher-order functions named `map*`
 that turn functions with input type `T`
 into functions with input type `collections.abc.Awaitable[T]`.
 
@@ -161,7 +161,7 @@ However, functions with input type `trcks.AwaitableResult[F, S]` tend to
 contain unnecessary `await` statements and
 violate the "do one thing and do it well" principle.
 Therefore, the module [trcks.fp.monads.awaitable_result][] provides
-some higher-order functions named `map_*`
+some higher-order functions named `map*`
 that turn functions with input type `F` and functions with input type `S`
 into functions with input type `trcks.AwaitableResult[F, S]`.
 

--- a/docs/usage/fp/async.md
+++ b/docs/usage/fp/async.md
@@ -56,7 +56,7 @@ into functions with input type `collections.abc.Awaitable[T]`.
     ...         input_path,
     ...         read_from_disk,
     ...         a.map_(transform),
-    ...         a.map_to_awaitable(lambda s: write_to_disk(s, output_path)),
+    ...         a.map_to_awaitable(write_to_disk, output_path),
     ...     )
     ...     return await pipe(p)
     ...
@@ -65,6 +65,12 @@ into functions with input type `collections.abc.Awaitable[T]`.
     Wrote 'Length: 13' to file output.txt.
 
     ```
+
+???+ tip "Passing extra arguments"
+    `map*` and `tap*` helpers forward any extra positional and keyword
+    arguments to the given function.
+    This is why `a.map_to_awaitable(write_to_disk, output_path)` can be used
+    instead of `a.map_to_awaitable(lambda s: write_to_disk(s, output_path))`.
 
 To understand what is going on here,
 let us have a look at the individual steps of the chain:
@@ -93,7 +99,7 @@ let us have a look at the individual steps of the chain:
     ...     "input.txt",
     ...     read_from_disk,
     ...     a.map_(transform),
-    ...     a.map_to_awaitable(lambda s: write_to_disk(s, "output.txt")),
+    ...     a.map_to_awaitable(write_to_disk, "output.txt"),
     ... )
     >>> asyncio.run(a.to_coroutine(pipe(p3)))
     Read 'Hello, world!' from file input.txt.
@@ -139,7 +145,7 @@ allows us to execute asynchronous side effects.
     ...         read_from_disk,
     ...         a.tap(lambda s: print(f"Read '{s}' from disk.")),
     ...         a.map_(transform),
-    ...         a.tap_to_awaitable(lambda s: write_to_disk(s, output_path)),
+    ...         a.tap_to_awaitable(write_to_disk, output_path),
     ...         a.tap(lambda s: print(f"Wrote '{s}' to disk.")),
     ...     )
     ...     return await pipe(p)
@@ -206,7 +212,7 @@ into functions with input type `trcks.AwaitableResult[F, S]`.
     ...         input_path,
     ...         read_from_disk,
     ...         ar.map_success(transform),
-    ...         ar.map_success_to_awaitable_result(lambda s: write_to_disk(s, output_path)),
+    ...         ar.map_success_to_awaitable_result(write_to_disk, output_path),
     ...     )
     ...     return await pipe(p)
     ...
@@ -255,7 +261,7 @@ let us have a look at the individual steps of the chain:
     ...     "input.txt",
     ...     read_from_disk,
     ...     ar.map_success(transform),
-    ...     ar.map_success_to_awaitable_result(lambda s: write_to_disk(s, "output.txt")),
+    ...     ar.map_success_to_awaitable_result(write_to_disk, "output.txt"),
     ... )
     >>> asyncio.run(ar.to_coroutine_result(pipe(p3)))
     Read 'Hello, world!' from file input.txt.
@@ -311,7 +317,7 @@ in the failure case or in the success case, respectively:
     ...         read_from_disk,
     ...         ar.tap_success(lambda s: print(f"LOG: Read '{s}' from disk.")),
     ...         ar.map_success(transform),
-    ...         ar.map_success_to_awaitable_result(lambda s: write_to_disk(s, output_path)),
+    ...         ar.map_success_to_awaitable_result(write_to_disk, output_path),
     ...         ar.tap_success(lambda _: print("LOG: Successfully wrote to disk.")),
     ...         ar.tap_failure(lambda err: print(f"LOG: Failed with error: {err}")),
     ...     )

--- a/docs/usage/fp/sync.md
+++ b/docs/usage/fp/sync.md
@@ -79,7 +79,7 @@ the following function must accept this `trcks.Result[F, S]` type as its input.
 However, functions with input type `trcks.Result[F, S]` tend to violate
 the "do one thing and do it well" principle.
 Therefore, the module [trcks.fp.monads.result][] provides
-some higher-order functions named `map_*`
+some higher-order functions named `map*`
 that turn functions with input type `F` and functions with input type `S`
 into functions with input type `trcks.Result[F, S]`.
 

--- a/docs/usage/fp/tuples.md
+++ b/docs/usage/fp/tuples.md
@@ -9,7 +9,7 @@
 If we want to apply a pipeline of functions to each element
 in a [tuple][],
 the module [trcks.fp.monads.tuple_][] provides
-some higher-order functions named `map_*` and `tap`
+some higher-order functions named `map*` and `tap*`
 that turn element-wise functions into functions
 operating on entire tuples.
 
@@ -427,7 +427,7 @@ a [trcks.AwaitableTuple][]`[T]` type,
 the following function must accept this [trcks.AwaitableTuple][]`[T]` type
 as its input.
 The module [trcks.fp.monads.awaitable_tuple][] provides
-some higher-order functions named `map_*`
+some higher-order functions named `map*`
 that turn element-wise functions
 into functions operating on [trcks.AwaitableTuple][] values.
 

--- a/docs/usage/oop/async.md
+++ b/docs/usage/oop/async.md
@@ -68,7 +68,7 @@ with "regular" functions:
     ...         Wrapper(core=input_path)
     ...         .map_to_awaitable(read_from_disk)
     ...         .map(transform)
-    ...         .map_to_awaitable(lambda s: write_to_disk(s, output_path))
+    ...         .map_to_awaitable(write_to_disk, output_path)
     ...         .core
     ...     )
     ...
@@ -77,6 +77,12 @@ with "regular" functions:
     Wrote 'Length: 13' to file output.txt.
 
     ```
+
+???+ tip "Passing extra arguments"
+    `map*` and `tap*` methods forward any extra positional and keyword
+    arguments to the given function.
+    This is why `.map_to_awaitable(write_to_disk, output_path)` can be used
+    instead of `.map_to_awaitable(lambda s: write_to_disk(s, output_path))`.
 
 To understand what is going on here,
 let us have a look at the individual steps of the chain:
@@ -100,7 +106,7 @@ let us have a look at the individual steps of the chain:
     AwaitableWrapper(core=<coroutine object ...>)
     >>> # 4. Apply the asynchronous function write_to_disk:
     >>> mapped_thrice: AwaitableWrapper[None] = mapped_twice.map_to_awaitable(
-    ...     lambda s: write_to_disk(s, "output.txt")
+    ...     write_to_disk, "output.txt"
     ... )
     >>> mapped_thrice
     AwaitableWrapper(core=<coroutine object ...>)
@@ -146,7 +152,7 @@ allows us to execute asynchronous side effects.
     ...         .map_to_awaitable(read_from_disk)
     ...         .tap(lambda s: print(f"Read '{s}' from disk."))
     ...         .map(transform)
-    ...         .tap_to_awaitable(lambda s: write_to_disk(s, output_path))
+    ...         .tap_to_awaitable(write_to_disk, output_path)
     ...         .tap(lambda s: print(f"Wrote '{s}' to disk."))
     ...         .core
     ...     )
@@ -206,7 +212,7 @@ with "regular" functions:
     ...         Wrapper(core=input_path)
     ...         .map_to_awaitable_result(read_from_disk)
     ...         .map_success(transform)
-    ...         .map_success_to_awaitable_result(lambda s: write_to_disk(s, output_path))
+    ...         .map_success_to_awaitable_result(write_to_disk, output_path)
     ...         .core
     ...     )
     ...
@@ -244,7 +250,7 @@ let us have a look at the individual steps of the chain:
     >>> mapped_thrice: AwaitableResultWrapper[
     ...     ReadErrorLiteral | WriteErrorLiteral, None
     ... ] = mapped_twice.map_success_to_awaitable_result(
-    ...     lambda s: write_to_disk(s, "output.txt")
+    ...     write_to_disk, "output.txt"
     ... )
     >>> mapped_thrice
     AwaitableResultWrapper(core=<coroutine object ...>)
@@ -292,7 +298,7 @@ in the failure case or in the success case, respectively:
     ...         .map_to_awaitable_result(read_from_disk)
     ...         .tap_success(lambda s: print(f"LOG: Read '{s}' from disk."))
     ...         .map_success(transform)
-    ...         .map_success_to_awaitable_result(lambda s: write_to_disk(s, output_path))
+    ...         .map_success_to_awaitable_result(write_to_disk, output_path)
     ...         .tap_success(lambda _: print("LOG: Successfully wrote to disk."))
     ...         .tap_failure(lambda err: print(f"LOG: Failed with error: {err}"))
     ...         .core

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,9 +75,8 @@ pyrefly = [
     "pyrefly>=1.2",
 ]
 pyright = [
-    # pyright versions older than 1.1.391 seem to have issues
-    # with reachability analysis in match statements:
-    "pyright>=1.1.391",
+    # pyright versions older than 1.1.392 seem to have issue with ParamSpec:
+    "pyright>=1.1.392",
     # pyright 1.1.406 and older report false positives for Python 3.14
     # (cf. https://github.com/microsoft/pyright/issues/11003):
     "pyright>=1.1.407; python_full_version>='3.14'",

--- a/src/trcks/fp/monads/awaitable.py
+++ b/src/trcks/fp/monads/awaitable.py
@@ -37,7 +37,7 @@ Example:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Concatenate, ParamSpec
 
 from trcks._typing import TypeVar
 from trcks.fp.composition import compose2
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 
 __docformat__ = "google"
 
+_P = ParamSpec("_P")
 _T = TypeVar("_T")
 _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2")
@@ -79,7 +80,9 @@ def construct(value: _T) -> Awaitable[_T]:
     return _construct(value)
 
 
-def map_(f: Callable[[_T1], _T2]) -> Callable[[Awaitable[_T1]], Awaitable[_T2]]:
+def map_(
+    f: Callable[Concatenate[_T1, _P], _T2], *args: _P.args, **kwargs: _P.kwargs
+) -> Callable[[Awaitable[_T1]], Awaitable[_T2]]:
     """Turn synchronous function into a function
     expecting and returning [collections.abc.Awaitable][].
 
@@ -87,6 +90,10 @@ def map_(f: Callable[[_T1], _T2]) -> Callable[[Awaitable[_T1]], Awaitable[_T2]]:
         f:
             The synchronous function to be transformed into
             a function expecting and returning a [collections.abc.Awaitable][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         The given function transformed into
@@ -112,11 +119,13 @@ def map_(f: Callable[[_T1], _T2]) -> Callable[[Awaitable[_T1]], Awaitable[_T2]]:
         'Length: 13'
 
     """
-    return map_to_awaitable(compose2((f, construct)))
+    return map_to_awaitable(compose2((f, construct)), *args, **kwargs)
 
 
 def map_to_awaitable(
-    f: Callable[[_T1], Awaitable[_T2]],
+    f: Callable[Concatenate[_T1, _P], Awaitable[_T2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[Awaitable[_T1]], Awaitable[_T2]]:
     """Turn [collections.abc.Awaitable][]-returning function into
     function expecting and returning [collections.abc.Awaitable][].
@@ -125,6 +134,10 @@ def map_to_awaitable(
         f:
             The [collections.abc.Awaitable][]-returning function to be transformed into
             a function expecting and returning a [collections.abc.Awaitable][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         The given function transformed into
@@ -149,12 +162,14 @@ def map_to_awaitable(
     """
 
     async def mapped_f(awaitable: Awaitable[_T1]) -> _T2:
-        return await f(await awaitable)
+        return await f(await awaitable, *args, **kwargs)
 
     return mapped_f
 
 
-def tap(f: Callable[[_T1], object]) -> Callable[[Awaitable[_T1]], Awaitable[_T1]]:
+def tap(
+    f: Callable[Concatenate[_T1, _P], object], *args: _P.args, **kwargs: _P.kwargs
+) -> Callable[[Awaitable[_T1]], Awaitable[_T1]]:
     """Turn synchronous function into a function
     expecting a [collections.abc.Awaitable][] and
     returning the same [collections.abc.Awaitable][].
@@ -164,6 +179,10 @@ def tap(f: Callable[[_T1], object]) -> Callable[[Awaitable[_T1]], Awaitable[_T1]
             The synchronous function to be transformed into a function
             expecting a [collections.abc.Awaitable][] and
             returning the same [collections.abc.Awaitable][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         The given function transformed into a function
@@ -187,11 +206,13 @@ def tap(f: Callable[[_T1], object]) -> Callable[[Awaitable[_T1]], Awaitable[_T1]
         >>> value
         'Hello, world!'
     """
-    return map_(i.tap(f))
+    return map_(i.tap(f, *args, **kwargs))
 
 
 def tap_to_awaitable(
-    f: Callable[[_T1], Awaitable[object]],
+    f: Callable[Concatenate[_T1, _P], Awaitable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[Awaitable[_T1]], Awaitable[_T1]]:
     """Turn [collections.abc.Awaitable][]-returning function into a function
     expecting a [collections.abc.Awaitable][] and
@@ -202,6 +223,10 @@ def tap_to_awaitable(
             The asynchronous function to be transformed into a function
             expecting a [collections.abc.Awaitable][] and
             returning the same [collections.abc.Awaitable][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         The given function transformed into a function
@@ -228,7 +253,7 @@ def tap_to_awaitable(
     """
 
     async def bypassed_f(value: _T1) -> _T1:
-        _ = await f(value)
+        _ = await f(value, *args, **kwargs)
         return value
 
     return map_to_awaitable(bypassed_f)

--- a/src/trcks/fp/monads/awaitable_result.py
+++ b/src/trcks/fp/monads/awaitable_result.py
@@ -38,7 +38,7 @@ Example:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Concatenate, ParamSpec
 
 from trcks._typing import Never, TypeVar, assert_type
 from trcks.fp.composition import compose2
@@ -55,6 +55,7 @@ __docformat__ = "google"
 _F = TypeVar("_F")
 _F1 = TypeVar("_F1")
 _F2 = TypeVar("_F2")
+_P = ParamSpec("_P")
 _S = TypeVar("_S")
 _S1 = TypeVar("_S1")
 _S2 = TypeVar("_S2")
@@ -190,7 +191,7 @@ def construct_success_from_awaitable(awtbl: Awaitable[_S]) -> AwaitableSuccess[_
 
 
 def map_failure(
-    f: Callable[[_F1], _F2],
+    f: Callable[Concatenate[_F1, _P], _F2], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F2, _S1]]:
     """Create function that maps [trcks.AwaitableFailure][]
     to [trcks.AwaitableFailure][] values.
@@ -199,6 +200,10 @@ def map_failure(
 
     Args:
         f: Synchronous function to apply to the [trcks.AwaitableFailure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.AwaitableFailure][] values to [trcks.AwaitableFailure][] values
@@ -221,11 +226,13 @@ def map_failure(
         >>> asyncio.run(ar.to_coroutine_result(a_rslt_2))
         ('success', 25.0)
     """
-    return a.map_(r.map_failure(f))
+    return a.map_(r.map_failure(f, *args, **kwargs))
 
 
 def map_failure_to_awaitable(
-    f: Callable[[_F1], Awaitable[_F2]],
+    f: Callable[Concatenate[_F1, _P], Awaitable[_F2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F2, _S1]]:
     """Create function that maps [trcks.AwaitableFailure][]
     to [trcks.AwaitableFailure][] values.
@@ -234,6 +241,10 @@ def map_failure_to_awaitable(
 
     Args:
         f: Asynchronous function to apply to the [trcks.AwaitableFailure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.AwaitableFailure][] values to [trcks.AwaitableFailure][] values
@@ -263,12 +274,14 @@ def map_failure_to_awaitable(
         ('success', 25.0)
     """
     return map_failure_to_awaitable_result(
-        compose2((f, construct_failure_from_awaitable))
+        compose2((f, construct_failure_from_awaitable)), *args, **kwargs
     )
 
 
 def map_failure_to_awaitable_result(
-    f: Callable[[_F1], AwaitableResult[_F2, _S2]],
+    f: Callable[Concatenate[_F1, _P], AwaitableResult[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F2, _S1 | _S2]]:
     """Create function that maps [trcks.AwaitableFailure][] values
     to [trcks.AwaitableResult][] values.
@@ -277,6 +290,10 @@ def map_failure_to_awaitable_result(
 
     Args:
         f: Asynchronous function to apply to the [trcks.AwaitableFailure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.AwaitableFailure][] values
@@ -312,7 +329,7 @@ def map_failure_to_awaitable_result(
     async def partially_mapped_f(rslt: Result[_F1, _S1]) -> Result[_F2, _S1 | _S2]:
         match rslt:
             case ("failure", value):
-                return await f(value)
+                return await f(value, *args, **kwargs)
             case ("success", _):
                 return rslt
             case _:  # pragma: no cover
@@ -324,7 +341,9 @@ def map_failure_to_awaitable_result(
 
 
 def map_failure_to_result(
-    f: Callable[[_F1], Result[_F2, _S2]],
+    f: Callable[Concatenate[_F1, _P], Result[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F2, _S1 | _S2]]:
     """Create function that maps [trcks.AwaitableFailure][] values
     to [trcks.AwaitableResult][] values.
@@ -333,6 +352,10 @@ def map_failure_to_result(
 
     Args:
         f: Synchronous function to apply to the [trcks.AwaitableFailure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.AwaitableFailure][] values to [trcks.AwaitableResult][] values
@@ -362,11 +385,11 @@ def map_failure_to_result(
         >>> asyncio.run(ar.to_coroutine_result(a_rslt_3))
         ('success', 25.0)
     """
-    return a.map_(r.map_failure_to_result(f))
+    return a.map_(r.map_failure_to_result(f, *args, **kwargs))
 
 
 def map_success(
-    f: Callable[[_S1], _S2],
+    f: Callable[Concatenate[_S1, _P], _S2], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F1, _S2]]:
     """Create function that maps [trcks.AwaitableSuccess][]
     to [trcks.AwaitableSuccess][] values.
@@ -375,6 +398,10 @@ def map_success(
 
     Args:
         f: Synchronous function to apply to the [trcks.AwaitableSuccess][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Leaves [trcks.AwaitableFailure][] values unchanged and
@@ -401,11 +428,13 @@ def map_success(
         >>> asyncio.run(ar.to_coroutine_result(a_rslt_2))
         ('success', 43)
     """
-    return a.map_(r.map_success(f))
+    return a.map_(r.map_success(f, *args, **kwargs))
 
 
 def map_success_to_awaitable(
-    f: Callable[[_S1], Awaitable[_S2]],
+    f: Callable[Concatenate[_S1, _P], Awaitable[_S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F1, _S2]]:
     """Create function that maps [trcks.AwaitableSuccess][]
     to [trcks.AwaitableSuccess][] values.
@@ -414,6 +443,10 @@ def map_success_to_awaitable(
 
     Args:
         f: Asynchronous function to apply to the [trcks.AwaitableSuccess][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Leaves [trcks.AwaitableFailure][] values unchanged and
@@ -446,12 +479,14 @@ def map_success_to_awaitable(
         ('success', 43)
     """
     return map_success_to_awaitable_result(
-        compose2((f, construct_success_from_awaitable))
+        compose2((f, construct_success_from_awaitable)), *args, **kwargs
     )
 
 
 def map_success_to_awaitable_result(
-    f: Callable[[_S1], AwaitableResult[_F2, _S2]],
+    f: Callable[Concatenate[_S1, _P], AwaitableResult[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F1 | _F2, _S2]]:
     """Create function that maps [trcks.AwaitableSuccess][] values
     to [trcks.AwaitableResult][] values.
@@ -460,6 +495,10 @@ def map_success_to_awaitable_result(
 
     Args:
         f: Asynchronous function to apply to the [trcks.AwaitableSuccess][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Leaves [trcks.AwaitableFailure][] values unchanged and
@@ -498,7 +537,7 @@ def map_success_to_awaitable_result(
             case ("failure", _):
                 return rslt
             case ("success", value):
-                return await f(value)
+                return await f(value, *args, **kwargs)
             case _:  # pragma: no cover
                 assert_type(rslt, Never)  # type: ignore[unreachable]  # pyright: ignore[reportUnreachable]
                 msg = f"{type(rslt).__name__!r} is not a valid Result"
@@ -508,7 +547,9 @@ def map_success_to_awaitable_result(
 
 
 def map_success_to_result(
-    f: Callable[[_S1], Result[_F2, _S2]],
+    f: Callable[Concatenate[_S1, _P], Result[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F1 | _F2, _S2]]:
     """Create function that maps [trcks.AwaitableSuccess][] values
     to [trcks.AwaitableResult][] values.
@@ -517,6 +558,10 @@ def map_success_to_result(
 
     Args:
         f: Synchronous function to apply to the [trcks.AwaitableSuccess][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Leaves [trcks.AwaitableFailure][] values unchanged and
@@ -548,11 +593,11 @@ def map_success_to_result(
         >>> asyncio.run(ar.to_coroutine_result(a_rslt_2))
         ('success', 5.0)
     """
-    return a.map_(r.map_success_to_result(f))
+    return a.map_(r.map_success_to_result(f, *args, **kwargs))
 
 
 def tap_failure(
-    f: Callable[[_F1], object],
+    f: Callable[Concatenate[_F1, _P], object], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F1, _S1]]:
     """Create function that applies a synchronous side effect
     to [trcks.AwaitableFailure][] values.
@@ -561,17 +606,23 @@ def tap_failure(
 
     Args:
         f: Synchronous side effect to apply to the [trcks.AwaitableFailure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.AwaitableFailure][] values and
             returns the original [trcks.AwaitableFailure][] value.
             Passes on [trcks.AwaitableSuccess][] values without side effects.
     """
-    return a.map_(r.tap_failure(f))
+    return a.map_(r.tap_failure(f, *args, **kwargs))
 
 
 def tap_failure_to_awaitable(
-    f: Callable[[_F1], Awaitable[object]],
+    f: Callable[Concatenate[_F1, _P], Awaitable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F1, _S1]]:
     """Create function that applies an asynchronous side effect
     to [trcks.AwaitableFailure][] values.
@@ -580,6 +631,10 @@ def tap_failure_to_awaitable(
 
     Args:
         f: Asynchronous side effect to apply to the [trcks.AwaitableFailure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.AwaitableFailure][] values and
@@ -588,14 +643,16 @@ def tap_failure_to_awaitable(
     """
 
     async def bypassed_f(value: _F1) -> _F1:
-        _ = await f(value)
+        _ = await f(value, *args, **kwargs)
         return value
 
     return map_failure_to_awaitable(bypassed_f)
 
 
 def tap_failure_to_awaitable_result(
-    f: Callable[[_F1], AwaitableResult[object, _S2]],
+    f: Callable[Concatenate[_F1, _P], AwaitableResult[object, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F1, _S1 | _S2]]:
     """Create function that applies an asynchronous side effect
     with return type [trcks.AwaitableResult][] to [trcks.AwaitableFailure][] values.
@@ -604,6 +661,10 @@ def tap_failure_to_awaitable_result(
 
     Args:
         f: Asynchronous side effect to apply to the [trcks.AwaitableFailure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.AwaitableFailure][] values.
@@ -615,7 +676,7 @@ def tap_failure_to_awaitable_result(
     """
 
     async def bypassed_f(value: _F1) -> Result[_F1, _S2]:
-        match await f(value):
+        match await f(value, *args, **kwargs):
             case ("failure", _):
                 return r.construct_failure(value)
             case ("success", _) as rslt:
@@ -629,7 +690,9 @@ def tap_failure_to_awaitable_result(
 
 
 def tap_failure_to_result(
-    f: Callable[[_F1], Result[object, _S2]],
+    f: Callable[Concatenate[_F1, _P], Result[object, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F1, _S1 | _S2]]:
     """Create function that applies a synchronous side effect
     with return type [trcks.Result][] to [trcks.AwaitableFailure][] values.
@@ -638,6 +701,10 @@ def tap_failure_to_result(
 
     Args:
         f: Synchronous side effect to apply to the [trcks.AwaitableFailure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.AwaitableFailure][] values.
@@ -647,11 +714,11 @@ def tap_failure_to_result(
             *this* [trcks.Success][] is returned.
             Passes on [trcks.AwaitableSuccess][] values without side effects.
     """
-    return a.map_(r.tap_failure_to_result(f))
+    return a.map_(r.tap_failure_to_result(f, *args, **kwargs))
 
 
 def tap_success(
-    f: Callable[[_S1], object],
+    f: Callable[Concatenate[_S1, _P], object], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F1, _S1]]:
     """Create function that applies a synchronous side effect
     to [trcks.AwaitableSuccess][] values.
@@ -660,17 +727,23 @@ def tap_success(
 
     Args:
         f: Synchronous side effect to apply to the [trcks.AwaitableSuccess][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Passes on [trcks.AwaitableFailure][] values without side effects.
             Applies the given side effect to [trcks.AwaitableSuccess][] values and
             returns the original [trcks.AwaitableSuccess][] value.
     """
-    return a.map_(r.tap_success(f))
+    return a.map_(r.tap_success(f, *args, **kwargs))
 
 
 def tap_success_to_awaitable(
-    f: Callable[[_S1], Awaitable[object]],
+    f: Callable[Concatenate[_S1, _P], Awaitable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F1, _S1]]:
     """Create function that applies an asynchronous side effect
     to [trcks.AwaitableSuccess][] values.
@@ -679,6 +752,10 @@ def tap_success_to_awaitable(
 
     Args:
         f: Asynchronous side effect to apply to the [trcks.AwaitableSuccess][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Passes on [trcks.AwaitableFailure][] values without side effects.
@@ -687,14 +764,16 @@ def tap_success_to_awaitable(
     """
 
     async def bypassed_f(value: _S1) -> _S1:
-        _ = await f(value)
+        _ = await f(value, *args, **kwargs)
         return value
 
     return map_success_to_awaitable(bypassed_f)
 
 
 def tap_success_to_awaitable_result(
-    f: Callable[[_S1], AwaitableResult[_F2, object]],
+    f: Callable[Concatenate[_S1, _P], AwaitableResult[_F2, object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F1 | _F2, _S1]]:
     """Create function that applies an asynchronous side effect
     with return type [trcks.AwaitableResult][] to [trcks.AwaitableSuccess][] values.
@@ -703,6 +782,10 @@ def tap_success_to_awaitable_result(
 
     Args:
         f: Asynchronous side effect to apply to the [trcks.AwaitableSuccess][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Passes on [trcks.AwaitableFailure][] values without side effects.
@@ -714,7 +797,7 @@ def tap_success_to_awaitable_result(
     """
 
     async def bypassed_f(value: _S1) -> Result[_F2, _S1]:
-        match await f(value):
+        match await f(value, *args, **kwargs):
             case ("failure", _) as rslt:
                 return rslt
             case ("success", _):
@@ -728,7 +811,9 @@ def tap_success_to_awaitable_result(
 
 
 def tap_success_to_result(
-    f: Callable[[_S1], Result[_F2, object]],
+    f: Callable[Concatenate[_S1, _P], Result[_F2, object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResult[_F1, _S1]], AwaitableResult[_F1 | _F2, _S1]]:
     """Create function that applies a synchronous side effect
     with return type [trcks.Result][] to [trcks.AwaitableSuccess][] values.
@@ -737,6 +822,10 @@ def tap_success_to_result(
 
     Args:
         f: Synchronous side effect to apply to the [trcks.AwaitableSuccess][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Passes on [trcks.AwaitableFailure][] values without side effects.
@@ -746,7 +835,7 @@ def tap_success_to_result(
             If the given side effect returns a [trcks.Success][],
             *the original* [trcks.AwaitableSuccess][] value is returned.
     """
-    return a.map_(r.tap_success_to_result(f))
+    return a.map_(r.tap_success_to_result(f, *args, **kwargs))
 
 
 async def to_coroutine_result(a_rslt: AwaitableResult[_F, _S]) -> Result[_F, _S]:

--- a/src/trcks/fp/monads/awaitable_result_tuple.py
+++ b/src/trcks/fp/monads/awaitable_result_tuple.py
@@ -41,7 +41,7 @@ Example:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Concatenate, ParamSpec
 
 from trcks._typing import Never, TypeVar, assert_type, deprecated
 from trcks.fp.composition import compose2
@@ -71,6 +71,7 @@ __docformat__ = "google"
 _F = TypeVar("_F")
 _F1 = TypeVar("_F1")
 _F2 = TypeVar("_F2")
+_P = ParamSpec("_P")
 _S = TypeVar("_S")
 _S1 = TypeVar("_S1")
 _S2 = TypeVar("_S2")
@@ -361,7 +362,7 @@ def construct_successes_from_tuple(
 
 
 def map_failure(
-    f: Callable[[_F1], _F2],
+    f: Callable[Concatenate[_F1, _P], _F2], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F2, _S1]]:
     """Create function that maps [trcks.AwaitableFailure][]
     to [trcks.AwaitableFailure][] values.
@@ -370,6 +371,10 @@ def map_failure(
 
     Args:
         f: Synchronous function to apply to the [trcks.AwaitableFailure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.AwaitableFailure][] values to [trcks.AwaitableFailure][] values
@@ -390,11 +395,13 @@ def map_failure(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_2))
         ('success', (1, 2))
     """
-    return a.map_(rt.map_failure(f))
+    return a.map_(rt.map_failure(f, *args, **kwargs))
 
 
 def map_failure_to_awaitable(
-    f: Callable[[_F1], Awaitable[_F2]],
+    f: Callable[Concatenate[_F1, _P], Awaitable[_F2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F2, _S1]]:
     """Create function that maps [trcks.AwaitableFailure][]
     to [trcks.AwaitableFailure][] values.
@@ -403,6 +410,10 @@ def map_failure_to_awaitable(
 
     Args:
         f: Asynchronous function to apply to the [trcks.AwaitableFailure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.AwaitableFailure][] values to [trcks.AwaitableFailure][] values
@@ -427,12 +438,14 @@ def map_failure_to_awaitable(
         ('success', (1, 2))
     """
     return map_failure_to_awaitable_result_iterable(
-        compose2((f, construct_failure_from_awaitable))
+        compose2((f, construct_failure_from_awaitable)), *args, **kwargs
     )
 
 
 def map_failure_to_awaitable_iterable(
-    f: Callable[[_F1], AwaitableIterable[_S2]],
+    f: Callable[Concatenate[_F1, _P], AwaitableIterable[_S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     Awaitable[SuccessTuple[_S1] | SuccessTuple[_S2]],
@@ -444,6 +457,10 @@ def map_failure_to_awaitable_iterable(
 
     Args:
         f: Asynchronous function to apply to the [trcks.AwaitableFailure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.AwaitableFailure][] values to [collections.abc.Iterable][]s
@@ -485,7 +502,7 @@ def map_failure_to_awaitable_iterable(
     ) -> SuccessTuple[_S1] | SuccessTuple[_S2]:
         match r_tpl:
             case ("failure", value):
-                return "success", tuple(await f(value))
+                return "success", tuple(await f(value, *args, **kwargs))
             case ("success", _):
                 return r_tpl
             case _:  # pragma: no cover
@@ -497,7 +514,9 @@ def map_failure_to_awaitable_iterable(
 
 
 def map_failure_to_awaitable_result(
-    f: Callable[[_F1], AwaitableResult[_F2, _S2]],
+    f: Callable[Concatenate[_F1, _P], AwaitableResult[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F2, _S1 | _S2],
@@ -509,6 +528,10 @@ def map_failure_to_awaitable_result(
 
     Args:
         f: Asynchronous function to apply to the [trcks.AwaitableFailure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.AwaitableFailure][] values to new
@@ -544,12 +567,14 @@ def map_failure_to_awaitable_result(
         ('success', (1, 2))
     """
     return map_failure_to_awaitable_result_iterable(
-        compose2((f, construct_from_awaitable_result))
+        compose2((f, construct_from_awaitable_result)), *args, **kwargs
     )
 
 
 def map_failure_to_awaitable_result_iterable(
-    f: Callable[[_F1], AwaitableResultIterable[_F2, _S2]],
+    f: Callable[Concatenate[_F1, _P], AwaitableResultIterable[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F2, _S1 | _S2],
@@ -561,6 +586,10 @@ def map_failure_to_awaitable_result_iterable(
 
     Args:
         f: Asynchronous function to apply to the [trcks.AwaitableFailure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.AwaitableFailure][] values to new
@@ -603,7 +632,7 @@ def map_failure_to_awaitable_result_iterable(
     ) -> ResultTuple[_F2, _S1 | _S2]:
         match r_tpl:
             case ("failure", value):
-                return r.map_success(tuple)(await f(value))
+                return r.map_success(tuple)(await f(value, *args, **kwargs))
             case ("success", _):
                 return r_tpl
             case _:  # pragma: no cover
@@ -616,7 +645,9 @@ def map_failure_to_awaitable_result_iterable(
 
 @deprecated("Use map_failure_to_awaitable_result_iterable instead")
 def map_failure_to_awaitable_result_tuple(
-    f: Callable[[_F1], AwaitableResultTuple[_F2, _S2]],
+    f: Callable[Concatenate[_F1, _P], AwaitableResultTuple[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F2, _S1 | _S2],
@@ -624,12 +655,16 @@ def map_failure_to_awaitable_result_tuple(
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.map_failure_to_awaitable_result_iterable][].
     """
-    return map_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+    return map_failure_to_awaitable_result_iterable(
+        f, *args, **kwargs
+    )  # pragma: no cover
 
 
 @deprecated("Use map_failure_to_awaitable_iterable instead")
 def map_failure_to_awaitable_tuple(
-    f: Callable[[_F1], AwaitableTuple[_S2]],
+    f: Callable[Concatenate[_F1, _P], AwaitableTuple[_S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     Awaitable[SuccessTuple[_S1] | SuccessTuple[_S2]],
@@ -637,11 +672,13 @@ def map_failure_to_awaitable_tuple(
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.map_failure_to_awaitable_iterable][].
     """
-    return map_failure_to_awaitable_iterable(f)  # pragma: no cover
+    return map_failure_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def map_failure_to_iterable(
-    f: Callable[[_F1], Iterable[_S2]],
+    f: Callable[Concatenate[_F1, _P], Iterable[_S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     Awaitable[SuccessTuple[_S1] | SuccessTuple[_S2]],
@@ -653,6 +690,10 @@ def map_failure_to_iterable(
 
     Args:
         f: Synchronous function to apply to the [trcks.AwaitableFailure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.AwaitableFailure][] values to [collections.abc.Iterable][]s
@@ -682,11 +723,13 @@ def map_failure_to_iterable(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_3))
         ('success', (1, 2))
     """
-    return a.map_(rt.map_failure_to_iterable(f))
+    return a.map_(rt.map_failure_to_iterable(f, *args, **kwargs))
 
 
 def map_failure_to_result(
-    f: Callable[[_F1], Result[_F2, _S2]],
+    f: Callable[Concatenate[_F1, _P], Result[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F2, _S1 | _S2],
@@ -698,6 +741,10 @@ def map_failure_to_result(
 
     Args:
         f: Synchronous function to apply to the [trcks.AwaitableFailure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.AwaitableFailure][] values to new
@@ -726,11 +773,13 @@ def map_failure_to_result(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_3))
         ('success', (1, 2))
     """
-    return a.map_(rt.map_failure_to_result(f))
+    return a.map_(rt.map_failure_to_result(f, *args, **kwargs))
 
 
 def map_failure_to_result_iterable(
-    f: Callable[[_F1], ResultIterable[_F2, _S2]],
+    f: Callable[Concatenate[_F1, _P], ResultIterable[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F2, _S1 | _S2],
@@ -742,6 +791,10 @@ def map_failure_to_result_iterable(
 
     Args:
         f: Synchronous function to apply to the [trcks.AwaitableFailure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.AwaitableFailure][] values to new
@@ -773,12 +826,14 @@ def map_failure_to_result_iterable(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_3))
         ('success', (1, 2))
     """
-    return a.map_(rt.map_failure_to_result_iterable(f))
+    return a.map_(rt.map_failure_to_result_iterable(f, *args, **kwargs))
 
 
 @deprecated("Use map_failure_to_result_iterable instead")
 def map_failure_to_result_tuple(
-    f: Callable[[_F1], ResultTuple[_F2, _S2]],
+    f: Callable[Concatenate[_F1, _P], ResultTuple[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F2, _S1 | _S2],
@@ -786,12 +841,14 @@ def map_failure_to_result_tuple(
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.map_failure_to_result_iterable][].
     """
-    return map_failure_to_result_iterable(f)  # pragma: no cover
+    return map_failure_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 @deprecated("Use map_failure_to_iterable instead")
 def map_failure_to_tuple(
-    f: Callable[[_F1], tuple[_S2, ...]],
+    f: Callable[Concatenate[_F1, _P], tuple[_S2, ...]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     Awaitable[SuccessTuple[_S1] | SuccessTuple[_S2]],
@@ -799,11 +856,11 @@ def map_failure_to_tuple(
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.map_failure_to_iterable][].
     """
-    return map_failure_to_iterable(f)  # pragma: no cover
+    return map_failure_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def map_successes(
-    f: Callable[[_S1], _S2],
+    f: Callable[Concatenate[_S1, _P], _S2], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S2]]:
     """Map a synchronous function over each element
     in a [trcks.AwaitableResultTuple][].
@@ -812,6 +869,10 @@ def map_successes(
 
     Args:
         f: Function to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Function that transforms [trcks.AwaitableSuccessTuple][] values
@@ -833,11 +894,13 @@ def map_successes(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_2))
         ('failure', 'not found')
     """
-    return a.map_(rt.map_successes(f))
+    return a.map_(rt.map_successes(f, *args, **kwargs))
 
 
 def map_successes_to_awaitable(
-    f: Callable[[_S1], Awaitable[_S2]],
+    f: Callable[Concatenate[_S1, _P], Awaitable[_S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S2]]:
     """Map an awaitable-returning function over each element
     in a [trcks.AwaitableResultTuple][].
@@ -846,6 +909,10 @@ def map_successes_to_awaitable(
 
     Args:
         f: Asynchronous function to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Function that transforms [trcks.AwaitableSuccessTuple][] values
@@ -871,12 +938,14 @@ def map_successes_to_awaitable(
         ('failure', 'not found')
     """
     return map_successes_to_awaitable_result_iterable(
-        compose2((f, construct_successes_from_awaitable))
+        compose2((f, construct_successes_from_awaitable)), *args, **kwargs
     )
 
 
 def map_successes_to_awaitable_iterable(
-    f: Callable[[_S1], AwaitableIterable[_S2]],
+    f: Callable[Concatenate[_S1, _P], AwaitableIterable[_S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S2]]:
     """Map an awaitable-[collections.abc.Iterable][]-returning function
     over each element in a [trcks.AwaitableResultTuple][].
@@ -885,6 +954,10 @@ def map_successes_to_awaitable_iterable(
 
     Args:
         f: Asynchronous function to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Function that flat-maps [trcks.AwaitableSuccessTuple][] values
@@ -910,12 +983,14 @@ def map_successes_to_awaitable_iterable(
         ('failure', 'oops')
     """
     return map_successes_to_awaitable_result_iterable(
-        compose2((f, construct_successes_from_awaitable_iterable))
+        compose2((f, construct_successes_from_awaitable_iterable)), *args, **kwargs
     )
 
 
 def map_successes_to_awaitable_result(
-    f: Callable[[_S1], AwaitableResult[_F2, _S2]],
+    f: Callable[Concatenate[_S1, _P], AwaitableResult[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1 | _F2, _S2],
@@ -928,6 +1003,10 @@ def map_successes_to_awaitable_result(
 
     Args:
         f: Asynchronous function to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Function that maps over [trcks.AwaitableSuccessTuple][] values and
@@ -963,12 +1042,14 @@ def map_successes_to_awaitable_result(
         ('failure', 'oops')
     """
     return map_successes_to_awaitable_result_iterable(
-        compose2((f, construct_from_awaitable_result))
+        compose2((f, construct_from_awaitable_result)), *args, **kwargs
     )
 
 
 def map_successes_to_awaitable_result_iterable(
-    f: Callable[[_S1], AwaitableResultIterable[_F2, _S2]],
+    f: Callable[Concatenate[_S1, _P], AwaitableResultIterable[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1 | _F2, _S2],
@@ -981,6 +1062,10 @@ def map_successes_to_awaitable_result_iterable(
 
     Args:
         f: Asynchronous function to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Function that flat-maps [trcks.AwaitableSuccessTuple][] values and
@@ -1029,7 +1114,7 @@ def map_successes_to_awaitable_result_iterable(
             case ("success", s1s):
                 s2s: list[_S2] = []
                 for s1 in s1s:
-                    match await f(s1):
+                    match await f(s1, *args, **kwargs):
                         case ("failure", _) as output_r_tpl:
                             return output_r_tpl
                         case ("success", additional_s2s):
@@ -1052,7 +1137,9 @@ def map_successes_to_awaitable_result_iterable(
 
 @deprecated("Use map_successes_to_awaitable_result_iterable instead")
 def map_successes_to_awaitable_result_tuple(
-    f: Callable[[_S1], AwaitableResultTuple[_F2, _S2]],
+    f: Callable[Concatenate[_S1, _P], AwaitableResultTuple[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1 | _F2, _S2],
@@ -1060,21 +1147,27 @@ def map_successes_to_awaitable_result_tuple(
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.map_successes_to_awaitable_result_iterable][].
     """
-    return map_successes_to_awaitable_result_iterable(f)  # pragma: no cover
+    return map_successes_to_awaitable_result_iterable(
+        f, *args, **kwargs
+    )  # pragma: no cover
 
 
 @deprecated("Use map_successes_to_awaitable_iterable instead")
 def map_successes_to_awaitable_tuple(
-    f: Callable[[_S1], AwaitableTuple[_S2]],
+    f: Callable[Concatenate[_S1, _P], AwaitableTuple[_S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S2]]:
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.map_successes_to_awaitable_iterable][].
     """
-    return map_successes_to_awaitable_iterable(f)  # pragma: no cover
+    return map_successes_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def map_successes_to_iterable(
-    f: Callable[[_S1], Iterable[_S2]],
+    f: Callable[Concatenate[_S1, _P], Iterable[_S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S2]]:
     """Map a [collections.abc.Iterable][]-returning function over each element
     in a [trcks.AwaitableResultTuple][].
@@ -1083,6 +1176,10 @@ def map_successes_to_iterable(
 
     Args:
         f: Synchronous function to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Function that flat-maps over [trcks.AwaitableSuccessTuple][] values.
@@ -1098,11 +1195,13 @@ def map_successes_to_iterable(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl))
         ('success', (1, 1, 2, 2))
     """
-    return a.map_(rt.map_successes_to_iterable(f))
+    return a.map_(rt.map_successes_to_iterable(f, *args, **kwargs))
 
 
 def map_successes_to_result(
-    f: Callable[[_S1], Result[_F2, _S2]],
+    f: Callable[Concatenate[_S1, _P], Result[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1 | _F2, _S2],
@@ -1115,6 +1214,10 @@ def map_successes_to_result(
 
     Args:
         f: Synchronous function to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Function that maps over [trcks.AwaitableSuccessTuple][] values and
@@ -1145,11 +1248,13 @@ def map_successes_to_result(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_3))
         ('failure', 'oops')
     """
-    return a.map_(rt.map_successes_to_result(f))
+    return a.map_(rt.map_successes_to_result(f, *args, **kwargs))
 
 
 def map_successes_to_result_iterable(
-    f: Callable[[_S1], ResultIterable[_F2, _S2]],
+    f: Callable[Concatenate[_S1, _P], ResultIterable[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1 | _F2, _S2],
@@ -1162,6 +1267,10 @@ def map_successes_to_result_iterable(
 
     Args:
         f: Synchronous function to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Function that flat-maps [trcks.AwaitableSuccessTuple][] values and
@@ -1188,12 +1297,14 @@ def map_successes_to_result_iterable(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_2))
         ('failure', 'oops')
     """
-    return a.map_(rt.map_successes_to_result_iterable(f))
+    return a.map_(rt.map_successes_to_result_iterable(f, *args, **kwargs))
 
 
 @deprecated("Use map_successes_to_result_iterable instead")
 def map_successes_to_result_tuple(
-    f: Callable[[_S1], ResultTuple[_F2, _S2]],
+    f: Callable[Concatenate[_S1, _P], ResultTuple[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1 | _F2, _S2],
@@ -1201,21 +1312,23 @@ def map_successes_to_result_tuple(
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.map_successes_to_result_iterable][].
     """
-    return map_successes_to_result_iterable(f)  # pragma: no cover
+    return map_successes_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 @deprecated("Use map_successes_to_iterable instead")
 def map_successes_to_tuple(
-    f: Callable[[_S1], tuple[_S2, ...]],
+    f: Callable[Concatenate[_S1, _P], tuple[_S2, ...]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S2]]:
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.map_successes_to_iterable][].
     """
-    return map_successes_to_iterable(f)  # pragma: no cover
+    return map_successes_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def tap_failure(
-    f: Callable[[_F1], object],
+    f: Callable[Concatenate[_F1, _P], object], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S1]]:
     """Apply a synchronous side effect to [trcks.AwaitableFailure][] values.
 
@@ -1223,6 +1336,10 @@ def tap_failure(
 
     Args:
         f: Synchronous side effect to apply to the [trcks.AwaitableFailure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.AwaitableFailure][] values and
@@ -1246,11 +1363,13 @@ def tap_failure(
         >>> r_tpl_2
         ('success', (1,))
     """
-    return a.map_(rt.tap_failure(f))
+    return a.map_(rt.tap_failure(f, *args, **kwargs))
 
 
 def tap_failure_to_awaitable(
-    f: Callable[[_F1], Awaitable[object]],
+    f: Callable[Concatenate[_F1, _P], Awaitable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S1]]:
     """Apply an asynchronous side effect to [trcks.AwaitableFailure][] values.
 
@@ -1258,6 +1377,10 @@ def tap_failure_to_awaitable(
 
     Args:
         f: Asynchronous side effect to apply to the [trcks.AwaitableFailure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.AwaitableFailure][] values and
@@ -1284,14 +1407,16 @@ def tap_failure_to_awaitable(
     """
 
     async def bypassed_f(value: _F1) -> _F1:
-        _ = await f(value)
+        _ = await f(value, *args, **kwargs)
         return value
 
     return map_failure_to_awaitable(bypassed_f)
 
 
 def tap_failure_to_awaitable_iterable(
-    f: Callable[[_F1], AwaitableIterable[object]],
+    f: Callable[Concatenate[_F1, _P], AwaitableIterable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     Awaitable[SuccessTuple[_F1] | SuccessTuple[_S1]],
@@ -1307,6 +1432,10 @@ def tap_failure_to_awaitable_iterable(
 
     Args:
         f: Asynchronous side effect to apply to the [trcks.AwaitableFailure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.AwaitableFailure][] values and
@@ -1343,13 +1472,15 @@ def tap_failure_to_awaitable_iterable(
     """
 
     async def bypassed_f(value: _F1) -> list[_F1]:
-        return [value for _ in await f(value)]
+        return [value for _ in await f(value, *args, **kwargs)]
 
     return map_failure_to_awaitable_iterable(bypassed_f)
 
 
 def tap_failure_to_awaitable_result(
-    f: Callable[[_F1], AwaitableResult[object, _S2]],
+    f: Callable[Concatenate[_F1, _P], AwaitableResult[object, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1, _S1 | _S2],
@@ -1361,6 +1492,10 @@ def tap_failure_to_awaitable_result(
 
     Args:
         f: Asynchronous side effect to apply to the [trcks.AwaitableFailure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.AwaitableFailure][] values.
@@ -1394,7 +1529,7 @@ def tap_failure_to_awaitable_result(
     """
 
     async def bypassed_f(value: _F1) -> ResultTuple[_F1, _S2]:
-        match await f(value):
+        match await f(value, *args, **kwargs):
             case ("failure", _):
                 return r.construct_failure(value)
             case ("success", s2):
@@ -1408,7 +1543,9 @@ def tap_failure_to_awaitable_result(
 
 
 def tap_failure_to_awaitable_result_iterable(
-    f: Callable[[_F1], AwaitableResultIterable[object, _S2]],
+    f: Callable[Concatenate[_F1, _P], AwaitableResultIterable[object, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1, _S1 | _S2],
@@ -1420,6 +1557,10 @@ def tap_failure_to_awaitable_result_iterable(
 
     Args:
         f: Asynchronous side effect to apply to the [trcks.AwaitableFailure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.AwaitableFailure][] values.
@@ -1456,7 +1597,7 @@ def tap_failure_to_awaitable_result_iterable(
     """
 
     async def bypassed_f(value: _F1) -> ResultIterable[_F1, _S2]:
-        match await f(value):
+        match await f(value, *args, **kwargs):
             case ("failure", _):
                 return r.construct_failure(value)
             case ("success", _) as r_it:
@@ -1471,7 +1612,9 @@ def tap_failure_to_awaitable_result_iterable(
 
 @deprecated("Use tap_failure_to_awaitable_result_iterable instead")
 def tap_failure_to_awaitable_result_tuple(
-    f: Callable[[_F1], AwaitableResultTuple[object, _S2]],
+    f: Callable[Concatenate[_F1, _P], AwaitableResultTuple[object, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1, _S1 | _S2],
@@ -1479,12 +1622,16 @@ def tap_failure_to_awaitable_result_tuple(
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.tap_failure_to_awaitable_result_iterable][].
     """
-    return tap_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+    return tap_failure_to_awaitable_result_iterable(
+        f, *args, **kwargs
+    )  # pragma: no cover
 
 
 @deprecated("Use tap_failure_to_awaitable_iterable instead")
 def tap_failure_to_awaitable_tuple(
-    f: Callable[[_F1], AwaitableTuple[object]],
+    f: Callable[Concatenate[_F1, _P], AwaitableTuple[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     Awaitable[SuccessTuple[_F1] | SuccessTuple[_S1]],
@@ -1492,11 +1639,13 @@ def tap_failure_to_awaitable_tuple(
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.tap_failure_to_awaitable_iterable][].
     """
-    return tap_failure_to_awaitable_iterable(f)  # pragma: no cover
+    return tap_failure_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def tap_failure_to_iterable(
-    f: Callable[[_F1], Iterable[object]],
+    f: Callable[Concatenate[_F1, _P], Iterable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     Awaitable[SuccessTuple[_F1] | SuccessTuple[_S1]],
@@ -1512,6 +1661,10 @@ def tap_failure_to_iterable(
 
     Args:
         f: Synchronous side effect to apply to the [trcks.AwaitableFailure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.AwaitableFailure][] values and
@@ -1541,11 +1694,13 @@ def tap_failure_to_iterable(
         >>> r_tpl_2
         ('success', (1,))
     """
-    return a.map_(rt.tap_failure_to_iterable(f))
+    return a.map_(rt.tap_failure_to_iterable(f, *args, **kwargs))
 
 
 def tap_failure_to_result(
-    f: Callable[[_F1], Result[object, _S2]],
+    f: Callable[Concatenate[_F1, _P], Result[object, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1, _S1 | _S2],
@@ -1557,6 +1712,10 @@ def tap_failure_to_result(
 
     Args:
         f: Synchronous side effect to apply to the [trcks.AwaitableFailure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.AwaitableFailure][] values.
@@ -1587,11 +1746,13 @@ def tap_failure_to_result(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_3))
         ('success', (1,))
     """
-    return a.map_(rt.tap_failure_to_result(f))
+    return a.map_(rt.tap_failure_to_result(f, *args, **kwargs))
 
 
 def tap_failure_to_result_iterable(
-    f: Callable[[_F1], ResultIterable[object, _S2]],
+    f: Callable[Concatenate[_F1, _P], ResultIterable[object, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1, _S1 | _S2],
@@ -1603,6 +1764,10 @@ def tap_failure_to_result_iterable(
 
     Args:
         f: Synchronous side effect to apply to the [trcks.AwaitableFailure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.AwaitableFailure][] values.
@@ -1637,12 +1802,14 @@ def tap_failure_to_result_iterable(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_3))
         ('success', (1,))
     """
-    return a.map_(rt.tap_failure_to_result_iterable(f))
+    return a.map_(rt.tap_failure_to_result_iterable(f, *args, **kwargs))
 
 
 @deprecated("Use tap_failure_to_result_iterable instead")
 def tap_failure_to_result_tuple(
-    f: Callable[[_F1], ResultTuple[object, _S2]],
+    f: Callable[Concatenate[_F1, _P], ResultTuple[object, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1, _S1 | _S2],
@@ -1650,12 +1817,14 @@ def tap_failure_to_result_tuple(
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.tap_failure_to_result_iterable][].
     """
-    return tap_failure_to_result_iterable(f)  # pragma: no cover
+    return tap_failure_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 @deprecated("Use tap_failure_to_iterable instead")
 def tap_failure_to_tuple(
-    f: Callable[[_F1], tuple[object, ...]],
+    f: Callable[Concatenate[_F1, _P], tuple[object, ...]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     Awaitable[SuccessTuple[_F1] | SuccessTuple[_S1]],
@@ -1663,11 +1832,11 @@ def tap_failure_to_tuple(
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.tap_failure_to_iterable][].
     """
-    return tap_failure_to_iterable(f)  # pragma: no cover
+    return tap_failure_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def tap_successes(
-    f: Callable[[_S1], object],
+    f: Callable[Concatenate[_S1, _P], object], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S1]]:
     """Apply a synchronous side effect to each element
     in a [trcks.AwaitableResultTuple][].
@@ -1676,6 +1845,10 @@ def tap_successes(
 
     Args:
         f: Synchronous side effect to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect and returns the original
@@ -1699,11 +1872,13 @@ def tap_successes(
         >>> r_tpl_2
         ('failure', 'oops')
     """
-    return a.map_(rt.tap_successes(f))
+    return a.map_(rt.tap_successes(f, *args, **kwargs))
 
 
 def tap_successes_to_awaitable(
-    f: Callable[[_S1], Awaitable[object]],
+    f: Callable[Concatenate[_S1, _P], Awaitable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S1]]:
     """Apply an asynchronous side effect to each element
     in a [trcks.AwaitableResultTuple][].
@@ -1712,6 +1887,10 @@ def tap_successes_to_awaitable(
 
     Args:
         f: Asynchronous side effect to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect and returns the original
@@ -1738,14 +1917,16 @@ def tap_successes_to_awaitable(
     """
 
     async def bypassed_f(value: _S1) -> _S1:
-        _ = await f(value)
+        _ = await f(value, *args, **kwargs)
         return value
 
     return map_successes_to_awaitable(bypassed_f)
 
 
 def tap_successes_to_awaitable_iterable(
-    f: Callable[[_S1], AwaitableIterable[object]],
+    f: Callable[Concatenate[_S1, _P], AwaitableIterable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S1]]:
     """Apply an asynchronous [collections.abc.Iterable][]-returning side effect
     to each element in a [trcks.AwaitableResultTuple][].
@@ -1757,6 +1938,10 @@ def tap_successes_to_awaitable_iterable(
 
     Args:
         f: Asynchronous side effect to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect and returns a
@@ -1782,13 +1967,15 @@ def tap_successes_to_awaitable_iterable(
     """
 
     async def bypassed_f(value: _S1) -> list[_S1]:
-        return [value for _ in await f(value)]
+        return [value for _ in await f(value, *args, **kwargs)]
 
     return map_successes_to_awaitable_iterable(bypassed_f)
 
 
 def tap_successes_to_awaitable_result(
-    f: Callable[[_S1], AwaitableResult[_F2, object]],
+    f: Callable[Concatenate[_S1, _P], AwaitableResult[_F2, object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1 | _F2, _S1],
@@ -1800,6 +1987,10 @@ def tap_successes_to_awaitable_result(
 
     Args:
         f: Asynchronous side effect to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to each success element.
@@ -1834,12 +2025,14 @@ def tap_successes_to_awaitable_result(
         ('failure', 'oops')
     """
     return tap_successes_to_awaitable_result_iterable(
-        compose2((f, construct_from_awaitable_result))
+        compose2((f, construct_from_awaitable_result)), *args, **kwargs
     )
 
 
 def tap_successes_to_awaitable_result_iterable(
-    f: Callable[[_S1], AwaitableResultIterable[_F2, object]],
+    f: Callable[Concatenate[_S1, _P], AwaitableResultIterable[_F2, object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1 | _F2, _S1],
@@ -1852,6 +2045,10 @@ def tap_successes_to_awaitable_result_iterable(
 
     Args:
         f: Asynchronous side effect to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to each success element.
@@ -1888,7 +2085,7 @@ def tap_successes_to_awaitable_result_iterable(
     """
 
     async def tapped_f(s1: _S1) -> ResultIterable[_F2, _S1]:
-        match await f(s1):
+        match await f(s1, *args, **kwargs):
             case ("failure", _) as r_it:
                 return r_it
             case ("success", objs):
@@ -1903,7 +2100,9 @@ def tap_successes_to_awaitable_result_iterable(
 
 @deprecated("Use tap_successes_to_awaitable_result_iterable instead")
 def tap_successes_to_awaitable_result_tuple(
-    f: Callable[[_S1], AwaitableResultTuple[_F2, object]],
+    f: Callable[Concatenate[_S1, _P], AwaitableResultTuple[_F2, object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1 | _F2, _S1],
@@ -1911,21 +2110,27 @@ def tap_successes_to_awaitable_result_tuple(
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.tap_successes_to_awaitable_result_iterable][].
     """
-    return tap_successes_to_awaitable_result_iterable(f)  # pragma: no cover
+    return tap_successes_to_awaitable_result_iterable(
+        f, *args, **kwargs
+    )  # pragma: no cover
 
 
 @deprecated("Use tap_successes_to_awaitable_iterable instead")
 def tap_successes_to_awaitable_tuple(
-    f: Callable[[_S1], AwaitableTuple[object]],
+    f: Callable[Concatenate[_S1, _P], AwaitableTuple[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S1]]:
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.tap_successes_to_awaitable_iterable][].
     """
-    return tap_successes_to_awaitable_iterable(f)  # pragma: no cover
+    return tap_successes_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def tap_successes_to_iterable(
-    f: Callable[[_S1], Iterable[object]],
+    f: Callable[Concatenate[_S1, _P], Iterable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S1]]:
     """Apply a [collections.abc.Iterable][]-returning side effect to each element
     in a [trcks.AwaitableResultTuple][].
@@ -1937,6 +2142,10 @@ def tap_successes_to_iterable(
 
     Args:
         f: Synchronous side effect to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect and returns a
@@ -1957,11 +2166,13 @@ def tap_successes_to_iterable(
         >>> r_tpl
         ('success', (7, 7))
     """
-    return a.map_(rt.tap_successes_to_iterable(f))
+    return a.map_(rt.tap_successes_to_iterable(f, *args, **kwargs))
 
 
 def tap_successes_to_result(
-    f: Callable[[_S1], Result[_F2, object]],
+    f: Callable[Concatenate[_S1, _P], Result[_F2, object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1 | _F2, _S1],
@@ -1973,6 +2184,10 @@ def tap_successes_to_result(
 
     Args:
         f: Synchronous side effect to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to each success element.
@@ -2002,11 +2217,13 @@ def tap_successes_to_result(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_3))
         ('failure', 'oops')
     """
-    return a.map_(rt.tap_successes_to_result(f))
+    return a.map_(rt.tap_successes_to_result(f, *args, **kwargs))
 
 
 def tap_successes_to_result_iterable(
-    f: Callable[[_S1], ResultIterable[_F2, object]],
+    f: Callable[Concatenate[_S1, _P], ResultIterable[_F2, object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1 | _F2, _S1],
@@ -2018,6 +2235,10 @@ def tap_successes_to_result_iterable(
 
     Args:
         f: Synchronous side effect to apply to each success element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to each success element.
@@ -2053,12 +2274,14 @@ def tap_successes_to_result_iterable(
         >>> asyncio.run(art.to_coroutine_result_tuple(a_r_tpl_3))
         ('failure', 'oops')
     """
-    return a.map_(rt.tap_successes_to_result_iterable(f))
+    return a.map_(rt.tap_successes_to_result_iterable(f, *args, **kwargs))
 
 
 @deprecated("Use tap_successes_to_result_iterable instead")
 def tap_successes_to_result_tuple(
-    f: Callable[[_S1], ResultTuple[_F2, object]],
+    f: Callable[Concatenate[_S1, _P], ResultTuple[_F2, object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[
     [AwaitableResultTuple[_F1, _S1]],
     AwaitableResultTuple[_F1 | _F2, _S1],
@@ -2066,17 +2289,19 @@ def tap_successes_to_result_tuple(
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.tap_successes_to_result_iterable][].
     """
-    return tap_successes_to_result_iterable(f)  # pragma: no cover
+    return tap_successes_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 @deprecated("Use tap_successes_to_iterable instead")
 def tap_successes_to_tuple(
-    f: Callable[[_S1], tuple[object, ...]],
+    f: Callable[Concatenate[_S1, _P], tuple[object, ...]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableResultTuple[_F1, _S1]], AwaitableResultTuple[_F1, _S1]]:
     """Deprecated alias for
     [trcks.fp.monads.awaitable_result_tuple.tap_successes_to_iterable][].
     """
-    return tap_successes_to_iterable(f)  # pragma: no cover
+    return tap_successes_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 async def to_coroutine_result_tuple(

--- a/src/trcks/fp/monads/awaitable_tuple.py
+++ b/src/trcks/fp/monads/awaitable_tuple.py
@@ -54,7 +54,7 @@ Example:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Concatenate, ParamSpec
 
 from trcks._typing import TypeVar, deprecated
 from trcks.fp.composition import compose2
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
 
 __docformat__ = "google"
 
+_P = ParamSpec("_P")
 _T = TypeVar("_T")
 _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2")
@@ -171,7 +172,7 @@ def construct_from_tuple(tpl: tuple[_T, ...]) -> AwaitableTuple[_T]:
 
 
 def map_(
-    f: Callable[[_T1], _T2],
+    f: Callable[Concatenate[_T1, _P], _T2], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[AwaitableTuple[_T1]], AwaitableTuple[_T2]]:
     """Turn synchronous function into a function
     expecting and returning [trcks.AwaitableTuple][]s
@@ -182,6 +183,10 @@ def map_(
             The synchronous function to be transformed into
             a function expecting and returning
             [trcks.AwaitableTuple][]s of the same length.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         The given function transformed into
@@ -208,11 +213,13 @@ def map_(
         >>> asyncio.run(at.to_coroutine_tuple(a_tpl))
         (2, 4, 6)
     """
-    return a.map_(t.map_(f))
+    return a.map_(t.map_(f, *args, **kwargs))
 
 
 def map_to_awaitable(
-    f: Callable[[_T1], Awaitable[_T2]],
+    f: Callable[Concatenate[_T1, _P], Awaitable[_T2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableTuple[_T1]], AwaitableTuple[_T2]]:
     """Turn [collections.abc.Awaitable][]-returning function into a function
     expecting and returning [trcks.AwaitableTuple][]s
@@ -223,6 +230,10 @@ def map_to_awaitable(
             The [collections.abc.Awaitable][]-returning function to be transformed
             into a function expecting and returning
             [trcks.AwaitableTuple][]s of the same length.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         The given function transformed into
@@ -246,11 +257,15 @@ def map_to_awaitable(
         >>> asyncio.run(at.to_coroutine_tuple(a_tpl))
         (2, 3)
     """
-    return map_to_awaitable_iterable(compose2((f, construct_from_awaitable)))
+    return map_to_awaitable_iterable(
+        compose2((f, construct_from_awaitable)), *args, **kwargs
+    )
 
 
 def map_to_awaitable_iterable(
-    f: Callable[[_T1], AwaitableIterable[_T2]],
+    f: Callable[Concatenate[_T1, _P], AwaitableIterable[_T2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableTuple[_T1]], AwaitableTuple[_T2]]:
     """Turn [trcks.AwaitableIterable][]-returning function into a function
     expecting and returning [trcks.AwaitableTuple][]s
@@ -261,6 +276,10 @@ def map_to_awaitable_iterable(
             The [trcks.AwaitableIterable][]-returning function to be transformed
             into a function expecting and returning
             [trcks.AwaitableTuple][]s of varying length.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         The given function transformed into
@@ -288,7 +307,7 @@ def map_to_awaitable_iterable(
     async def mapped_f(a_t1s: AwaitableTuple[_T1]) -> tuple[_T2, ...]:
         # `tuple` does not support asynchronous generators.
         # Therefore, we need to use a list comprehension and then convert it to a tuple:
-        t2s = [t2 for t1 in await a_t1s for t2 in await f(t1)]
+        t2s = [t2 for t1 in await a_t1s for t2 in await f(t1, *args, **kwargs)]
         return tuple(t2s)
 
     return mapped_f
@@ -296,16 +315,20 @@ def map_to_awaitable_iterable(
 
 @deprecated("Use map_to_awaitable_iterable instead")
 def map_to_awaitable_tuple(
-    f: Callable[[_T1], AwaitableTuple[_T2]],
+    f: Callable[Concatenate[_T1, _P], AwaitableTuple[_T2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableTuple[_T1]], AwaitableTuple[_T2]]:
     """Deprecated alias for
     [trcks.fp.monads.awaitable_tuple.map_to_awaitable_iterable][].
     """
-    return map_to_awaitable_iterable(f)  # pragma: no cover
+    return map_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def map_to_iterable(
-    f: Callable[[_T1], Iterable[_T2]],
+    f: Callable[Concatenate[_T1, _P], Iterable[_T2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableTuple[_T1]], AwaitableTuple[_T2]]:
     """Turn [collections.abc.Iterable][]-returning function into a function
     expecting and returning [trcks.AwaitableTuple][]s
@@ -316,6 +339,10 @@ def map_to_iterable(
             The [collections.abc.Iterable][]-returning function to be transformed
             into a function expecting and returning
             [trcks.AwaitableTuple][]s of varying length.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         The given function transformed into
@@ -338,19 +365,21 @@ def map_to_iterable(
         >>> asyncio.run(at.to_coroutine_tuple(a_tpl))
         (1, -1, 2, -2)
     """
-    return a.map_(t.map_to_iterable(f))
+    return a.map_(t.map_to_iterable(f, *args, **kwargs))
 
 
 @deprecated("Use map_to_iterable instead")
 def map_to_tuple(
-    f: Callable[[_T1], tuple[_T2, ...]],
+    f: Callable[Concatenate[_T1, _P], tuple[_T2, ...]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableTuple[_T1]], AwaitableTuple[_T2]]:
     """Deprecated alias for [trcks.fp.monads.awaitable_tuple.map_to_iterable][]."""
-    return map_to_iterable(f)  # pragma: no cover
+    return map_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def tap(
-    f: Callable[[_T1], object],
+    f: Callable[Concatenate[_T1, _P], object], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[AwaitableTuple[_T1]], AwaitableTuple[_T1]]:
     """Turn synchronous function into a function
     expecting a [trcks.AwaitableTuple][] and
@@ -361,6 +390,10 @@ def tap(
             The synchronous function to be transformed into a function
             expecting a [trcks.AwaitableTuple][] and
             returning the same [trcks.AwaitableTuple][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         The given function transformed into a function
@@ -387,11 +420,13 @@ def tap(
         >>> tpl
         (1, 2)
     """
-    return a.map_(t.tap(f))
+    return a.map_(t.tap(f, *args, **kwargs))
 
 
 def tap_to_awaitable(
-    f: Callable[[_T1], Awaitable[object]],
+    f: Callable[Concatenate[_T1, _P], Awaitable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableTuple[_T1]], AwaitableTuple[_T1]]:
     """Turn [collections.abc.Awaitable][]-returning function into a function
     expecting a [trcks.AwaitableTuple][] and
@@ -402,6 +437,10 @@ def tap_to_awaitable(
             The [collections.abc.Awaitable][]-returning function to be transformed
             into a function expecting a [trcks.AwaitableTuple][] and
             returning the same [trcks.AwaitableTuple][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         The given function transformed into a function
@@ -430,14 +469,16 @@ def tap_to_awaitable(
     """
 
     async def bypassed_f(t1: _T1) -> _T1:
-        _ = await f(t1)
+        _ = await f(t1, *args, **kwargs)
         return t1
 
     return map_to_awaitable(bypassed_f)
 
 
 def tap_to_awaitable_iterable(
-    f: Callable[[_T1], AwaitableIterable[object]],
+    f: Callable[Concatenate[_T1, _P], AwaitableIterable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableTuple[_T1]], AwaitableTuple[_T1]]:
     """Turn a [trcks.AwaitableIterable][]-returning side effect into a function
     expecting a [trcks.AwaitableTuple][] and returning a [trcks.AwaitableTuple][]
@@ -450,6 +491,10 @@ def tap_to_awaitable_iterable(
             into a function expecting a [trcks.AwaitableTuple][] and
             returning a [trcks.AwaitableTuple][] where each original element is
             repeated once per element returned by the side effect.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         The given function transformed into a function
@@ -477,7 +522,7 @@ def tap_to_awaitable_iterable(
     """
 
     async def bypassed_f(t1: _T1) -> tuple[_T1, ...]:
-        objs = await f(t1)
+        objs = await f(t1, *args, **kwargs)
         return tuple(t1 for _ in objs)
 
     return map_to_awaitable_iterable(bypassed_f)
@@ -485,16 +530,20 @@ def tap_to_awaitable_iterable(
 
 @deprecated("Use tap_to_awaitable_iterable instead")
 def tap_to_awaitable_tuple(
-    f: Callable[[_T1], AwaitableTuple[object]],
+    f: Callable[Concatenate[_T1, _P], AwaitableTuple[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableTuple[_T1]], AwaitableTuple[_T1]]:
     """Deprecated alias for
     [trcks.fp.monads.awaitable_tuple.tap_to_awaitable_iterable][].
     """
-    return tap_to_awaitable_iterable(f)  # pragma: no cover
+    return tap_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def tap_to_iterable(
-    f: Callable[[_T1], Iterable[object]],
+    f: Callable[Concatenate[_T1, _P], Iterable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableTuple[_T1]], AwaitableTuple[_T1]]:
     """Turn a [collections.abc.Iterable][]-returning side effect into a function
     expecting a [trcks.AwaitableTuple][] and returning a [trcks.AwaitableTuple][]
@@ -507,6 +556,10 @@ def tap_to_iterable(
             into a function expecting a [trcks.AwaitableTuple][] and
             returning a [trcks.AwaitableTuple][] where each original element is
             repeated once per element returned by the side effect.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         The given function transformed into a function
@@ -531,15 +584,17 @@ def tap_to_iterable(
         >>> asyncio.run(at.to_coroutine_tuple(a_tpl))
         (1, 2, 2, 3, 3, 4, 4, 4)
     """
-    return a.map_(t.tap_to_iterable(f))
+    return a.map_(t.tap_to_iterable(f, *args, **kwargs))
 
 
 @deprecated("Use tap_to_iterable instead")
 def tap_to_tuple(
-    f: Callable[[_T1], tuple[object, ...]],
+    f: Callable[Concatenate[_T1, _P], tuple[object, ...]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[AwaitableTuple[_T1]], AwaitableTuple[_T1]]:
     """Deprecated alias for [trcks.fp.monads.awaitable_tuple.tap_to_iterable][]."""
-    return tap_to_iterable(f)  # pragma: no cover
+    return tap_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 async def to_coroutine_tuple(a_tpl: AwaitableTuple[_T]) -> tuple[_T, ...]:

--- a/src/trcks/fp/monads/identity.py
+++ b/src/trcks/fp/monads/identity.py
@@ -4,20 +4,27 @@ Provides utilities for functional composition of synchronous functions.
 """
 
 from collections.abc import Callable
-from typing import TypeVar
+from typing import Concatenate, ParamSpec, TypeVar
 
 __docformat__ = "google"
 
+_P = ParamSpec("_P")
 _T = TypeVar("_T")
 
 
-def tap(f: Callable[[_T], object]) -> Callable[[_T], _T]:
+def tap(
+    f: Callable[Concatenate[_T, _P], object], *args: _P.args, **kwargs: _P.kwargs
+) -> Callable[[_T], _T]:
     """Turn synchronous function into a function that returns its input.
 
     Args:
         f:
             The synchronous function to be transformed into
             a function that returns its input.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         The given function transformed into a function that returns its input.
@@ -35,7 +42,7 @@ def tap(f: Callable[[_T], object]) -> Callable[[_T], _T]:
     """
 
     def bypassed_f(value: _T) -> _T:
-        _ = f(value)
+        _ = f(value, *args, **kwargs)
         return value
 
     return bypassed_f

--- a/src/trcks/fp/monads/result.py
+++ b/src/trcks/fp/monads/result.py
@@ -72,7 +72,7 @@ Example:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Concatenate, ParamSpec
 
 from trcks._typing import Never, TypeVar, assert_type
 from trcks.fp.composition import compose2
@@ -89,6 +89,7 @@ __docformat__ = "google"
 _F = TypeVar("_F")
 _F1 = TypeVar("_F1")
 _F2 = TypeVar("_F2")
+_P = ParamSpec("_P")
 _S = TypeVar("_S")
 _S1 = TypeVar("_S1")
 _S2 = TypeVar("_S2")
@@ -129,7 +130,7 @@ def construct_success(value: _S) -> Success[_S]:
 
 
 def map_failure(
-    f: Callable[[_F1], _F2],
+    f: Callable[Concatenate[_F1, _P], _F2], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[Result[_F1, _S1]], Result[_F2, _S1]]:
     """Create function that maps [trcks.Failure][] values to [trcks.Failure][] values.
 
@@ -137,6 +138,10 @@ def map_failure(
 
     Args:
         f: Function to apply to the [trcks.Failure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.Failure][] values to new [trcks.Failure][] values
@@ -151,11 +156,13 @@ def map_failure(
         >>> add_prefix_to_failure(("success", 25.0))
         ('success', 25.0)
     """
-    return map_failure_to_result(compose2((f, construct_failure)))
+    return map_failure_to_result(compose2((f, construct_failure)), *args, **kwargs)
 
 
 def map_failure_to_result(
-    f: Callable[[_F1], Result[_F2, _S2]],
+    f: Callable[Concatenate[_F1, _P], Result[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[Result[_F1, _S1]], Result[_F2, _S1 | _S2]]:
     """Create function that maps [trcks.Failure][] values
     to [trcks.Failure][] and [trcks.Success][] values.
@@ -164,6 +171,10 @@ def map_failure_to_result(
 
     Args:
         f: Function to apply to the [trcks.Failure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.Failure][] values to [trcks.Failure][] and [trcks.Success][] values
@@ -186,7 +197,7 @@ def map_failure_to_result(
     def mapped_f(rslt: Result[_F1, _S1]) -> Result[_F2, _S1 | _S2]:
         match rslt:
             case ("failure", value):
-                return f(value)
+                return f(value, *args, **kwargs)
             case ("success", _):
                 return rslt
             case _:  # pragma: no cover
@@ -198,7 +209,7 @@ def map_failure_to_result(
 
 
 def map_success(
-    f: Callable[[_S1], _S2],
+    f: Callable[Concatenate[_S1, _P], _S2], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[Result[_F1, _S1]], Result[_F1, _S2]]:
     """Create function that maps [trcks.Success][] values to [trcks.Success][] values.
 
@@ -206,6 +217,10 @@ def map_success(
 
     Args:
         f: Function to apply to the [trcks.Success][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Leaves [trcks.Failure][] values unchanged and
@@ -223,11 +238,13 @@ def map_success(
         >>> increase_success(("success", 42))
         ('success', 43)
     """
-    return map_success_to_result(compose2((f, construct_success)))
+    return map_success_to_result(compose2((f, construct_success)), *args, **kwargs)
 
 
 def map_success_to_result(
-    f: Callable[[_S1], Result[_F2, _S2]],
+    f: Callable[Concatenate[_S1, _P], Result[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[Result[_F1, _S1]], Result[_F1 | _F2, _S2]]:
     """Create function that maps [trcks.Success][] values
     to [trcks.Failure][] and [trcks.Success][] values.
@@ -236,6 +253,10 @@ def map_success_to_result(
 
     Args:
         f: Function to apply to the [trcks.Success][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Leaves [trcks.Failure][] values unchanged and
@@ -265,7 +286,7 @@ def map_success_to_result(
             case ("failure", _):
                 return rslt
             case ("success", value):
-                return f(value)
+                return f(value, *args, **kwargs)
             case _:  # pragma: no cover
                 assert_type(rslt, Never)  # type: ignore[unreachable]  # pyright: ignore[reportUnreachable]
                 msg = f"{type(rslt).__name__!r} is not a valid Result"
@@ -275,7 +296,7 @@ def map_success_to_result(
 
 
 def tap_failure(
-    f: Callable[[_F1], object],
+    f: Callable[Concatenate[_F1, _P], object], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[Result[_F1, _S1]], Result[_F1, _S1]]:
     """Create function that applies a side effect to [trcks.Failure][] values.
 
@@ -283,17 +304,23 @@ def tap_failure(
 
     Args:
         f: Side effect to apply to the [trcks.Failure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.Failure][] values and
             returns the original [trcks.Failure][] value.
             Passes on [trcks.Success][] values without side effects.
     """
-    return map_failure(i.tap(f))
+    return map_failure(i.tap(f, *args, **kwargs))
 
 
 def tap_failure_to_result(
-    f: Callable[[_F1], Result[object, _S2]],
+    f: Callable[Concatenate[_F1, _P], Result[object, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[Result[_F1, _S1]], Result[_F1, _S1 | _S2]]:
     """Create function that applies a side effect with return type [trcks.Result][]
     to [trcks.Failure][] values.
@@ -302,6 +329,10 @@ def tap_failure_to_result(
 
     Args:
         f: Side effect to apply to the [trcks.Failure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.Failure][] values.
@@ -313,7 +344,7 @@ def tap_failure_to_result(
     """
 
     def bypassed_f(value: _F1) -> Result[_F1, _S2]:
-        match f(value):
+        match f(value, *args, **kwargs):
             case ("failure", _):
                 return construct_failure(value)
             case ("success", _) as rslt:
@@ -327,7 +358,7 @@ def tap_failure_to_result(
 
 
 def tap_success(
-    f: Callable[[_S1], object],
+    f: Callable[Concatenate[_S1, _P], object], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[Result[_F1, _S1]], Result[_F1, _S1]]:
     """Create function that applies a side effect to [trcks.Success][] values.
 
@@ -335,17 +366,23 @@ def tap_success(
 
     Args:
         f: Side effect to apply to the [trcks.Success][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Passes on [trcks.Failure][] values without side effects.
             Applies the given side effect to [trcks.Success][] values and
             returns the original [trcks.Success][] value.
     """
-    return map_success(i.tap(f))
+    return map_success(i.tap(f, *args, **kwargs))
 
 
 def tap_success_to_result(
-    f: Callable[[_S1], Result[_F2, object]],
+    f: Callable[Concatenate[_S1, _P], Result[_F2, object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[Result[_F1, _S1]], Result[_F1 | _F2, _S1]]:
     """Create function that applies a side effect with return type [trcks.Result][]
     to [trcks.Success][] values.
@@ -354,6 +391,10 @@ def tap_success_to_result(
 
     Args:
         f: Side effect to apply to the [trcks.Success][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Passes on [trcks.Failure][] values without side effects.
@@ -365,7 +406,7 @@ def tap_success_to_result(
     """
 
     def bypassed_f(value: _S1) -> Result[_F2, _S1]:
-        match f(value):
+        match f(value, *args, **kwargs):
             case ("failure", _) as rslt:
                 return rslt
             case ("success", _):

--- a/src/trcks/fp/monads/result_tuple.py
+++ b/src/trcks/fp/monads/result_tuple.py
@@ -34,7 +34,7 @@ Example:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Concatenate, ParamSpec
 
 from trcks._typing import Never, TypeVar, assert_type, deprecated
 from trcks.fp.composition import compose2
@@ -51,6 +51,7 @@ __docformat__ = "google"
 _F = TypeVar("_F")
 _F1 = TypeVar("_F1")
 _F2 = TypeVar("_F2")
+_P = ParamSpec("_P")
 _S = TypeVar("_S")
 _S1 = TypeVar("_S1")
 _S2 = TypeVar("_S2")
@@ -162,7 +163,7 @@ def construct_successes_from_tuple(tpl: tuple[_S, ...]) -> SuccessTuple[_S]:
 
 
 def map_failure(
-    f: Callable[[_F1], _F2],
+    f: Callable[Concatenate[_F1, _P], _F2], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F2, _S1]]:
     """Create function that maps [trcks.Failure][] values to [trcks.Failure][] values.
 
@@ -170,6 +171,10 @@ def map_failure(
 
     Args:
         f: Function to apply to the [trcks.Failure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.Failure][] values to new [trcks.Failure][] values
@@ -191,11 +196,13 @@ def map_failure(
         >>> add_prefix(("success", (1, 2)))
         ('success', (1, 2))
     """
-    return r.map_failure(f)
+    return r.map_failure(f, *args, **kwargs)
 
 
 def map_failure_to_iterable(
-    f: Callable[[_F1], Iterable[_S2]],
+    f: Callable[Concatenate[_F1, _P], Iterable[_S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], SuccessTuple[_S1] | SuccessTuple[_S2]]:
     """Create function that maps [trcks.Failure][] values
     to homogeneous [tuple][]s.
@@ -204,6 +211,10 @@ def map_failure_to_iterable(
 
     Args:
         f: Function to apply to the [trcks.Failure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.Failure][] values to homogeneous [tuple][]s wrapped
@@ -235,7 +246,7 @@ def map_failure_to_iterable(
     ) -> SuccessTuple[_S1] | SuccessTuple[_S2]:
         match r_tpl:
             case ("failure", value):
-                return "success", tuple(f(value))
+                return "success", tuple(f(value, *args, **kwargs))
             case ("success", _):
                 return r_tpl
             case _:  # pragma: no cover
@@ -247,7 +258,9 @@ def map_failure_to_iterable(
 
 
 def map_failure_to_result(
-    f: Callable[[_F1], Result[_F2, _S2]],
+    f: Callable[Concatenate[_F1, _P], Result[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], Result[_F2, tuple[_S1, ...] | tuple[_S2, ...]]]:
     """Create function that maps [trcks.Failure][] values
     to [trcks.Failure][] and [trcks.Success][] values.
@@ -256,6 +269,10 @@ def map_failure_to_result(
 
     Args:
         f: Function to apply to the [trcks.Failure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.Failure][] values to new [trcks.Failure][] and [trcks.Success][]
@@ -281,11 +298,15 @@ def map_failure_to_result(
         >>> recover_from_not_found(("success", (1, 2)))
         ('success', (1, 2))
     """
-    return map_failure_to_result_iterable(compose2((f, construct_from_result)))
+    return map_failure_to_result_iterable(
+        compose2((f, construct_from_result)), *args, **kwargs
+    )
 
 
 def map_failure_to_result_iterable(
-    f: Callable[[_F1], ResultIterable[_F2, _S2]],
+    f: Callable[Concatenate[_F1, _P], ResultIterable[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], Result[_F2, tuple[_S1, ...] | tuple[_S2, ...]]]:
     """Create function that maps [trcks.Failure][] values
     to new [trcks.ResultTuple][] values.
@@ -294,6 +315,10 @@ def map_failure_to_result_iterable(
 
     Args:
         f: Function to apply to the [trcks.Failure][] values.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps [trcks.Failure][] values to new [trcks.ResultTuple][] values
@@ -319,29 +344,33 @@ def map_failure_to_result_iterable(
         >>> recover_from_not_found(("success", (1, 2)))
         ('success', (1, 2))
     """
-    return r.map_failure_to_result(compose2((f, r.map_success(tuple))))
+    return r.map_failure_to_result(compose2((f, r.map_success(tuple))), *args, **kwargs)
 
 
 @deprecated("Use map_failure_to_result_iterable instead")
 def map_failure_to_result_tuple(
-    f: Callable[[_F1], ResultTuple[_F2, _S2]],
+    f: Callable[Concatenate[_F1, _P], ResultTuple[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], Result[_F2, tuple[_S1, ...] | tuple[_S2, ...]]]:
     """Deprecated alias for
     [trcks.fp.monads.result_tuple.map_failure_to_result_iterable][].
     """
-    return map_failure_to_result_iterable(f)  # pragma: no cover
+    return map_failure_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 @deprecated("Use map_failure_to_iterable instead")
 def map_failure_to_tuple(
-    f: Callable[[_F1], tuple[_S2, ...]],
+    f: Callable[Concatenate[_F1, _P], tuple[_S2, ...]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], SuccessTuple[_S1] | SuccessTuple[_S2]]:
     """Deprecated alias for [trcks.fp.monads.result_tuple.map_failure_to_iterable][]."""
-    return map_failure_to_iterable(f)  # pragma: no cover
+    return map_failure_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def map_successes(
-    f: Callable[[_S1], _S2],
+    f: Callable[Concatenate[_S1, _P], _S2], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F1, _S2]]:
     """Create function that maps each element of a [trcks.SuccessTuple][]
     to a new element.
@@ -350,6 +379,10 @@ def map_successes(
 
     Args:
         f: Function to apply to each element of the [trcks.SuccessTuple][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Leaves [trcks.Failure][] values unchanged and
@@ -371,11 +404,13 @@ def map_successes(
         >>> double_integers(("failure", "not found"))
         ('failure', 'not found')
     """
-    return r.map_success(t.map_(f))
+    return r.map_success(t.map_(f, *args, **kwargs))
 
 
 def map_successes_to_iterable(
-    f: Callable[[_S1], Iterable[_S2]],
+    f: Callable[Concatenate[_S1, _P], Iterable[_S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F1, _S2]]:
     """Create function that maps each element of a [trcks.SuccessTuple][]
     to a [collections.abc.Iterable][].
@@ -384,6 +419,10 @@ def map_successes_to_iterable(
 
     Args:
         f: Function to apply to each element of the [trcks.SuccessTuple][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Leaves [trcks.Failure][] values unchanged and
@@ -405,11 +444,13 @@ def map_successes_to_iterable(
         >>> duplicate_integers(("failure", "not found"))
         ('failure', 'not found')
     """
-    return r.map_success(t.map_to_iterable(f))
+    return r.map_success(t.map_to_iterable(f, *args, **kwargs))
 
 
 def map_successes_to_result(
-    f: Callable[[_S1], Result[_F2, _S2]],
+    f: Callable[Concatenate[_S1, _P], Result[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F1 | _F2, _S2]]:
     """Create function that maps each element of a [trcks.SuccessTuple][]
     to [trcks.Failure][] and [trcks.Success][] values.
@@ -418,6 +459,10 @@ def map_successes_to_result(
 
     Args:
         f: Function to apply to each element of the [trcks.SuccessTuple][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Leaves [trcks.Failure][] values unchanged and
@@ -444,11 +489,15 @@ def map_successes_to_result(
         >>> double_if_positive(("failure", "oops"))
         ('failure', 'oops')
     """
-    return map_successes_to_result_iterable(compose2((f, construct_from_result)))
+    return map_successes_to_result_iterable(
+        compose2((f, construct_from_result)), *args, **kwargs
+    )
 
 
 def map_successes_to_result_iterable(
-    f: Callable[[_S1], ResultIterable[_F2, _S2]],
+    f: Callable[Concatenate[_S1, _P], ResultIterable[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F1 | _F2, _S2]]:
     """Create function that maps each element of a [trcks.SuccessTuple][]
     to new [trcks.ResultTuple][] values.
@@ -457,6 +506,10 @@ def map_successes_to_result_iterable(
 
     Args:
         f: Function to apply to each element of the [trcks.SuccessTuple][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Leaves [trcks.Failure][] values unchanged and
@@ -487,7 +540,7 @@ def map_successes_to_result_iterable(
     def partially_mapped_f(s1s: tuple[_S1, ...]) -> ResultTuple[_F2, _S2]:
         s2s: list[_S2] = []
         for s1 in s1s:
-            match f(s1):
+            match f(s1, *args, **kwargs):
                 case ("failure", _) as r_it:
                     return r_it
                 case ("success", additional_s2s):
@@ -514,26 +567,30 @@ def map_successes_to_result_iterable(
 
 @deprecated("Use map_successes_to_result_iterable instead")
 def map_successes_to_result_tuple(
-    f: Callable[[_S1], ResultTuple[_F2, _S2]],
+    f: Callable[Concatenate[_S1, _P], ResultTuple[_F2, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F1 | _F2, _S2]]:
     """Deprecated alias for
     [trcks.fp.monads.result_tuple.map_successes_to_result_iterable][].
     """
-    return map_successes_to_result_iterable(f)  # pragma: no cover
+    return map_successes_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 @deprecated("Use map_successes_to_iterable instead")
 def map_successes_to_tuple(
-    f: Callable[[_S1], tuple[_S2, ...]],
+    f: Callable[Concatenate[_S1, _P], tuple[_S2, ...]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F1, _S2]]:
     """Deprecated alias for
     [trcks.fp.monads.result_tuple.map_successes_to_iterable][].
     """
-    return map_successes_to_iterable(f)  # pragma: no cover
+    return map_successes_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def tap_failure(
-    f: Callable[[_F1], object],
+    f: Callable[Concatenate[_F1, _P], object], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F1, _S1]]:
     """Create function that applies a side effect to [trcks.Failure][] values.
 
@@ -541,6 +598,10 @@ def tap_failure(
 
     Args:
         f: Side effect to apply to the [trcks.Failure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.Failure][] values and
@@ -563,11 +624,13 @@ def tap_failure(
         >>> log_error(("success", (1,)))
         ('success', (1,))
     """
-    return r.tap_failure(f)
+    return r.tap_failure(f, *args, **kwargs)
 
 
 def tap_failure_to_iterable(
-    f: Callable[[_F1], Iterable[object]],
+    f: Callable[Concatenate[_F1, _P], Iterable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], SuccessTuple[_F1] | SuccessTuple[_S1]]:
     """Create function that applies a [collections.abc.Iterable][]-returning
     side effect to [trcks.Failure][] values.
@@ -576,6 +639,10 @@ def tap_failure_to_iterable(
 
     Args:
         f: Side effect to apply to the [trcks.Failure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.Failure][] values and converts them
@@ -607,13 +674,15 @@ def tap_failure_to_iterable(
     """
 
     def tapped_f(f1: _F1) -> tuple[_F1, ...]:
-        return tuple(f1 for _s2 in f(f1))
+        return tuple(f1 for _s2 in f(f1, *args, **kwargs))
 
     return map_failure_to_iterable(tapped_f)
 
 
 def tap_failure_to_result(
-    f: Callable[[_F1], Result[object, _S2]],
+    f: Callable[Concatenate[_F1, _P], Result[object, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], Result[_F1, tuple[_S1, ...] | tuple[_S2, ...]]]:
     """Create function that applies a side effect with return type [trcks.Result][]
     to [trcks.Failure][] values.
@@ -622,6 +691,10 @@ def tap_failure_to_result(
 
     Args:
         f: Side effect to apply to the [trcks.Failure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.Failure][] values.
@@ -649,14 +722,16 @@ def tap_failure_to_result(
         >>> recover_from_not_found(("success", (1, 2)))
         ('success', (1, 2))
     """
-    composed_f: Callable[[_F1], ResultTuple[object, _S2]] = compose2(
+    composed_f: Callable[Concatenate[_F1, _P], ResultTuple[object, _S2]] = compose2(
         (f, construct_from_result)
     )
-    return tap_failure_to_result_iterable(composed_f)
+    return tap_failure_to_result_iterable(composed_f, *args, **kwargs)
 
 
 def tap_failure_to_result_iterable(
-    f: Callable[[_F1], ResultIterable[object, _S2]],
+    f: Callable[Concatenate[_F1, _P], ResultIterable[object, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], Result[_F1, tuple[_S1, ...] | tuple[_S2, ...]]]:
     """Create function that applies a side effect with return type
     [trcks.ResultIterable][] to [trcks.Failure][] values.
@@ -665,6 +740,10 @@ def tap_failure_to_result_iterable(
 
     Args:
         f: Side effect to apply to the [trcks.Failure][] value.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to [trcks.Failure][] values.
@@ -692,29 +771,33 @@ def tap_failure_to_result_iterable(
         >>> recover_from_not_found(("success", (1, 2)))
         ('success', (1, 2))
     """
-    return r.tap_failure_to_result(compose2((f, r.map_success(tuple))))
+    return r.tap_failure_to_result(compose2((f, r.map_success(tuple))), *args, **kwargs)
 
 
 @deprecated("Use tap_failure_to_result_iterable instead")
 def tap_failure_to_result_tuple(
-    f: Callable[[_F1], ResultTuple[object, _S2]],
+    f: Callable[Concatenate[_F1, _P], ResultTuple[object, _S2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], Result[_F1, tuple[_S1, ...] | tuple[_S2, ...]]]:
     """Deprecated alias for
     [trcks.fp.monads.result_tuple.tap_failure_to_result_iterable][].
     """
-    return tap_failure_to_result_iterable(f)  # pragma: no cover
+    return tap_failure_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 @deprecated("Use tap_failure_to_iterable instead")
 def tap_failure_to_tuple(
-    f: Callable[[_F1], tuple[object, ...]],
+    f: Callable[Concatenate[_F1, _P], tuple[object, ...]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], SuccessTuple[_F1] | SuccessTuple[_S1]]:
     """Deprecated alias for [trcks.fp.monads.result_tuple.tap_failure_to_iterable][]."""
-    return tap_failure_to_iterable(f)  # pragma: no cover
+    return tap_failure_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def tap_successes(
-    f: Callable[[_S1], object],
+    f: Callable[Concatenate[_S1, _P], object], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F1, _S1]]:
     """Create function that applies a side effect to each element
     of a [trcks.SuccessTuple][].
@@ -723,6 +806,10 @@ def tap_successes(
 
     Args:
         f: Side effect to apply to each element of the [trcks.SuccessTuple][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Passes on [trcks.Failure][] values without side effects.
@@ -749,11 +836,13 @@ def tap_successes(
         >>> r_tpl_2
         ('failure', 'oops')
     """
-    return r.map_success(t.tap(f))
+    return r.map_success(t.tap(f, *args, **kwargs))
 
 
 def tap_successes_to_iterable(
-    f: Callable[[_S1], Iterable[object]],
+    f: Callable[Concatenate[_S1, _P], Iterable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F1, _S1]]:
     """Create function that applies a [collections.abc.Iterable][]-returning
     side effect to each element of a [trcks.SuccessTuple][].
@@ -762,6 +851,10 @@ def tap_successes_to_iterable(
 
     Args:
         f: Side effect to apply to each element of the [trcks.SuccessTuple][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Passes on [trcks.Failure][] values without side effects.
@@ -785,11 +878,13 @@ def tap_successes_to_iterable(
         Received: 7
         ('success', (7, 7))
     """
-    return r.map_success(t.tap_to_iterable(f))
+    return r.map_success(t.tap_to_iterable(f, *args, **kwargs))
 
 
 def tap_successes_to_result(
-    f: Callable[[_S1], Result[_F2, object]],
+    f: Callable[Concatenate[_S1, _P], Result[_F2, object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F1 | _F2, _S1]]:
     """Create function that applies a side effect with return type [trcks.Result][]
     to each element of a [trcks.SuccessTuple][].
@@ -798,6 +893,10 @@ def tap_successes_to_result(
 
     Args:
         f: Side effect to apply to each element of the [trcks.SuccessTuple][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Passes on [trcks.Failure][] values without side effects.
@@ -827,14 +926,16 @@ def tap_successes_to_result(
         >>> validate_positive(("failure", "oops"))
         ('failure', 'oops')
     """
-    composed_f: Callable[[_S1], ResultTuple[_F2, object]] = compose2(
+    composed_f: Callable[Concatenate[_S1, _P], ResultTuple[_F2, object]] = compose2(
         (f, construct_from_result)
     )
-    return tap_successes_to_result_iterable(composed_f)
+    return tap_successes_to_result_iterable(composed_f, *args, **kwargs)
 
 
 def tap_successes_to_result_iterable(
-    f: Callable[[_S1], ResultIterable[_F2, object]],
+    f: Callable[Concatenate[_S1, _P], ResultIterable[_F2, object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F1 | _F2, _S1]]:
     """Create function that applies a side effect with return type
     [trcks.ResultTuple][] to each element of a [trcks.SuccessTuple][].
@@ -843,6 +944,10 @@ def tap_successes_to_result_iterable(
 
     Args:
         f: Side effect to apply to each element of the [trcks.SuccessTuple][].
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Passes on [trcks.Failure][] values without side effects.
@@ -873,7 +978,7 @@ def tap_successes_to_result_iterable(
     """
 
     def tapped_f(s1: _S1) -> ResultTuple[_F2, _S1]:
-        match f(s1):
+        match f(s1, *args, **kwargs):
             case ("failure", _) as r_it:
                 return r_it
             case ("success", s2s):
@@ -888,19 +993,23 @@ def tap_successes_to_result_iterable(
 
 @deprecated("Use tap_successes_to_result_iterable instead")
 def tap_successes_to_result_tuple(
-    f: Callable[[_S1], ResultTuple[_F2, object]],
+    f: Callable[Concatenate[_S1, _P], ResultTuple[_F2, object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F1 | _F2, _S1]]:
     """Deprecated alias for
     [trcks.fp.monads.result_tuple.tap_successes_to_result_iterable][].
     """
-    return tap_successes_to_result_iterable(f)  # pragma: no cover
+    return tap_successes_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 @deprecated("Use tap_successes_to_iterable instead")
 def tap_successes_to_tuple(
-    f: Callable[[_S1], tuple[object, ...]],
+    f: Callable[Concatenate[_S1, _P], tuple[object, ...]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[ResultTuple[_F1, _S1]], ResultTuple[_F1, _S1]]:
     """Deprecated alias for
     [trcks.fp.monads.result_tuple.tap_successes_to_iterable][].
     """
-    return tap_successes_to_iterable(f)  # pragma: no cover
+    return tap_successes_to_iterable(f, *args, **kwargs)  # pragma: no cover

--- a/src/trcks/fp/monads/tuple_.py
+++ b/src/trcks/fp/monads/tuple_.py
@@ -50,7 +50,7 @@ Example:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Concatenate, ParamSpec
 
 from trcks._typing import TypeVar, deprecated
 from trcks.fp.composition import compose2
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
 
 __docformat__ = "google"
 
+_P = ParamSpec("_P")
 _T = TypeVar("_T")
 _T1 = TypeVar("_T1")
 _T2 = TypeVar("_T2")
@@ -83,12 +84,18 @@ def construct(value: _T) -> tuple[_T,]:
     return (value,)
 
 
-def map_(f: Callable[[_T1], _T2]) -> Callable[[tuple[_T1, ...]], tuple[_T2, ...]]:
+def map_(
+    f: Callable[Concatenate[_T1, _P], _T2], *args: _P.args, **kwargs: _P.kwargs
+) -> Callable[[tuple[_T1, ...]], tuple[_T2, ...]]:
     """Create function that maps homogeneous [tuple][]s to
     homogeneous [tuple][]s of the same length.
 
     Args:
         f: Function to apply to each element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps homogeneous [tuple][]s to homogeneous [tuple][]s of the same length
@@ -110,17 +117,23 @@ def map_(f: Callable[[_T1], _T2]) -> Callable[[tuple[_T1, ...]], tuple[_T2, ...]
         >>> double_integers((1, 2, 3))
         (2, 4, 6)
     """
-    return map_to_iterable(compose2((f, construct)))
+    return map_to_iterable(compose2((f, construct)), *args, **kwargs)
 
 
 def map_to_iterable(
-    f: Callable[[_T1], Iterable[_T2]],
+    f: Callable[Concatenate[_T1, _P], Iterable[_T2]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[tuple[_T1, ...]], tuple[_T2, ...]]:
     """Create function that maps homogeneous [tuple][]s to
     homogeneous [tuple][]s of varying length.
 
     Args:
         f: Function to apply to each element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Maps homogeneous [tuple][]s to homogeneous [tuple][]s of varying length
@@ -140,27 +153,33 @@ def map_to_iterable(
     """
 
     def mapped_f(t1s: tuple[_T1, ...]) -> tuple[_T2, ...]:
-        return tuple(t2 for t1 in t1s for t2 in f(t1))
+        return tuple(t2 for t1 in t1s for t2 in f(t1, *args, **kwargs))
 
     return mapped_f
 
 
 @deprecated("Use map_to_iterable instead")
 def map_to_tuple(
-    f: Callable[[_T1], tuple[_T2, ...]],
+    f: Callable[Concatenate[_T1, _P], tuple[_T2, ...]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[tuple[_T1, ...]], tuple[_T2, ...]]:
     """Deprecated alias for [trcks.fp.monads.tuple_.map_to_iterable][]."""
-    return map_to_iterable(f)  # pragma: no cover
+    return map_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
 
 def tap(
-    f: Callable[[_T1], object],
+    f: Callable[Concatenate[_T1, _P], object], *args: _P.args, **kwargs: _P.kwargs
 ) -> Callable[[tuple[_T1, ...]], tuple[_T1, ...]]:
     """Create function that applies a side effect to each element of a homogeneous
     [tuple][].
 
     Args:
         f: Side effect to apply to each element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to each element of a homogeneous [tuple][] and
@@ -182,11 +201,13 @@ def tap(
         >>> tpl
         (1, 2, 3)
     """
-    return map_(i.tap(f))
+    return map_(i.tap(f, *args, **kwargs))
 
 
 def tap_to_iterable(
-    f: Callable[[_T1], Iterable[object]],
+    f: Callable[Concatenate[_T1, _P], Iterable[object]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[tuple[_T1, ...]], tuple[_T1, ...]]:
     """Create function that applies a side effect
     with return type [collections.abc.Iterable][]
@@ -194,6 +215,10 @@ def tap_to_iterable(
 
     Args:
         f: Side effect to apply to each element.
+        *args:
+            Positional arguments to be passed to `f`.
+        **kwargs:
+            Keyword arguments to be passed to `f`.
 
     Returns:
         Applies the given side effect to each element of a homogeneous [tuple][].
@@ -214,14 +239,16 @@ def tap_to_iterable(
     """
 
     def bypassed_f(t1: _T1) -> tuple[_T1, ...]:
-        return tuple(t1 for _t2 in f(t1))
+        return tuple(t1 for _t2 in f(t1, *args, **kwargs))
 
     return map_to_iterable(bypassed_f)
 
 
 @deprecated("Use tap_to_iterable instead")
 def tap_to_tuple(
-    f: Callable[[_T1], tuple[object, ...]],
+    f: Callable[Concatenate[_T1, _P], tuple[object, ...]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
 ) -> Callable[[tuple[_T1, ...]], tuple[_T1, ...]]:
     """Deprecated alias for [trcks.fp.monads.tuple_.tap_to_iterable][]."""
-    return tap_to_iterable(f)  # pragma: no cover
+    return tap_to_iterable(f, *args, **kwargs)  # pragma: no cover

--- a/src/trcks/oop/_awaitable_result_tuple_wrapper.py
+++ b/src/trcks/oop/_awaitable_result_tuple_wrapper.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, Concatenate, ParamSpec, final
 
 from trcks import ResultTuple
 from trcks._typing import Never, TypeVar, deprecated
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 __docformat__ = "google"
 
 _F = TypeVar("_F")
+_P = ParamSpec("_P")
 _S = TypeVar("_S")
 
 _F_default = TypeVar("_F_default", default=Never)
@@ -404,7 +405,10 @@ class AwaitableResultTupleWrapper(
         return cls.construct_successes_from_iterable(tpl)  # pragma: no cover
 
     def map_failure(
-        self, f: Callable[[_F_default_co], _F]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], _F],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co]:
         """Apply a synchronous function to the wrapped [trcks.Failure][] object.
 
@@ -412,6 +416,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -443,10 +451,15 @@ class AwaitableResultTupleWrapper(
             >>> asyncio.run(wrapper_2.core_as_coroutine)
             ('success', (1, 2))
         """
-        return AwaitableResultTupleWrapper(art.map_failure(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.map_failure(f, *args, **kwargs)(self.core)
+        )
 
     def map_failure_to_awaitable(
-        self, f: Callable[[_F_default_co], Awaitable[_F]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Awaitable[_F]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co]:
         """Apply an asynchronous function to the wrapped [trcks.Failure][] object.
 
@@ -454,6 +467,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -489,10 +506,15 @@ class AwaitableResultTupleWrapper(
             >>> asyncio.run(wrapper_2.core_as_coroutine)
             ('success', (1, 2))
         """
-        return AwaitableResultTupleWrapper(art.map_failure_to_awaitable(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.map_failure_to_awaitable(f, *args, **kwargs)(self.core)
+        )
 
     def map_failure_to_awaitable_iterable(
-        self, f: Callable[[_F_default_co], AwaitableIterable[_S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableIterable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
         """Apply an asynchronous function returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Failure][] object.
@@ -502,6 +524,10 @@ class AwaitableResultTupleWrapper(
         Args:
             f: The asynchronous function returning an
                 [collections.abc.Iterable][] to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -555,11 +581,14 @@ class AwaitableResultTupleWrapper(
         mapped_f: Callable[
             [AwaitableResultTuple[_F_default_co, _S_default_co]],
             AwaitableResultTuple[Never, _S_default_co | _S],
-        ] = art.map_failure_to_awaitable_iterable(f)
+        ] = art.map_failure_to_awaitable_iterable(f, *args, **kwargs)
         return AwaitableResultTupleWrapper(mapped_f(self.core))
 
     def map_failure_to_awaitable_result(
-        self, f: Callable[[_F_default_co], AwaitableResult[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResult[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Apply an asynchronous function with return type [trcks.AwaitableResult][]
         to the wrapped [trcks.Failure][] object.
@@ -568,6 +597,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -617,11 +650,14 @@ class AwaitableResultTupleWrapper(
             ('success', (1, 2))
         """
         return AwaitableResultTupleWrapper(
-            art.map_failure_to_awaitable_result(f)(self.core)
+            art.map_failure_to_awaitable_result(f, *args, **kwargs)(self.core)
         )
 
     def map_failure_to_awaitable_result_iterable(
-        self, f: Callable[[_F_default_co], AwaitableResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Apply an asynchronous function with return type
         [trcks.AwaitableResultIterable][] to the wrapped [trcks.Failure][] object.
@@ -630,6 +666,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -687,29 +727,42 @@ class AwaitableResultTupleWrapper(
             ('success', (1, 2))
         """
         return AwaitableResultTupleWrapper(
-            art.map_failure_to_awaitable_result_iterable(f)(self.core)
+            art.map_failure_to_awaitable_result_iterable(f, *args, **kwargs)(self.core)
         )
 
     @deprecated("Use map_failure_to_awaitable_result_iterable instead")
     def map_failure_to_awaitable_result_tuple(
-        self, f: Callable[[_F_default_co], AwaitableResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.map_failure_to_awaitable_result_iterable][].
         """
-        return self.map_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.map_failure_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_failure_to_awaitable_iterable instead")
     def map_failure_to_awaitable_tuple(
-        self, f: Callable[[_F_default_co], AwaitableTuple[_S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableTuple[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.map_failure_to_awaitable_iterable][].
         """
-        return self.map_failure_to_awaitable_iterable(f)  # pragma: no cover
+        return self.map_failure_to_awaitable_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def map_failure_to_iterable(
-        self, f: Callable[[_F_default_co], Iterable[_S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Iterable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
         """Apply a synchronous function returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Failure][] object.
@@ -719,6 +772,10 @@ class AwaitableResultTupleWrapper(
         Args:
             f: The synchronous function returning an
                 [collections.abc.Iterable][] to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -769,11 +826,14 @@ class AwaitableResultTupleWrapper(
         mapped_f: Callable[
             [AwaitableResultTuple[_F_default_co, _S_default_co]],
             AwaitableResultTuple[Never, _S_default_co | _S],
-        ] = art.map_failure_to_iterable(f)
+        ] = art.map_failure_to_iterable(f, *args, **kwargs)
         return AwaitableResultTupleWrapper(mapped_f(self.core))
 
     def map_failure_to_result(
-        self, f: Callable[[_F_default_co], Result[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Result[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Apply a synchronous function with return type [trcks.Result][]
         to the wrapped [trcks.Failure][] object.
@@ -782,6 +842,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -829,10 +893,15 @@ class AwaitableResultTupleWrapper(
             >>> asyncio.run(wrapper_3.core_as_coroutine)
             ('success', (1, 2))
         """
-        return AwaitableResultTupleWrapper(art.map_failure_to_result(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.map_failure_to_result(f, *args, **kwargs)(self.core)
+        )
 
     def map_failure_to_result_iterable(
-        self, f: Callable[[_F_default_co], ResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Apply a synchronous function with return type [trcks.ResultIterable][]
         to the wrapped [trcks.Failure][] object.
@@ -841,6 +910,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -889,29 +962,40 @@ class AwaitableResultTupleWrapper(
             ('success', (1, 2))
         """
         return AwaitableResultTupleWrapper(
-            art.map_failure_to_result_iterable(f)(self.core)
+            art.map_failure_to_result_iterable(f, *args, **kwargs)(self.core)
         )
 
     @deprecated("Use map_failure_to_result_iterable instead")
     def map_failure_to_result_tuple(
-        self, f: Callable[[_F_default_co], ResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.map_failure_to_result_iterable][].
         """
-        return self.map_failure_to_result_iterable(f)  # pragma: no cover
+        return self.map_failure_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_failure_to_iterable instead")
     def map_failure_to_tuple(
-        self, f: Callable[[_F_default_co], tuple[_S, ...]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], tuple[_S, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.map_failure_to_iterable][].
         """
-        return self.map_failure_to_iterable(f)  # pragma: no cover
+        return self.map_failure_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def map_successes(
-        self, f: Callable[[_S_default_co], _S]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], _S],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
         """Apply a synchronous function to each element in the wrapped
         [trcks.AwaitableSuccessTuple][].
@@ -920,6 +1004,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The synchronous function to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -952,10 +1040,15 @@ class AwaitableResultTupleWrapper(
             >>> asyncio.run(wrapper_2.core_as_coroutine)
             ('failure', 'not found')
         """
-        return AwaitableResultTupleWrapper(art.map_successes(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.map_successes(f, *args, **kwargs)(self.core)
+        )
 
     def map_successes_to_awaitable(
-        self, f: Callable[[_S_default_co], Awaitable[_S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Awaitable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
         """Apply an asynchronous function to each element in the wrapped
         [trcks.AwaitableSuccessTuple][].
@@ -964,6 +1057,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The asynchronous function to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1000,10 +1097,15 @@ class AwaitableResultTupleWrapper(
             >>> asyncio.run(wrapper_2.core_as_coroutine)
             ('failure', 'not found')
         """
-        return AwaitableResultTupleWrapper(art.map_successes_to_awaitable(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.map_successes_to_awaitable(f, *args, **kwargs)(self.core)
+        )
 
     def map_successes_to_awaitable_iterable(
-        self, f: Callable[[_S_default_co], AwaitableIterable[_S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableIterable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
         """Apply an asynchronous function returning an [collections.abc.Iterable][]
         to each element in the wrapped [trcks.AwaitableSuccessTuple][] and flatten.
@@ -1013,6 +1115,10 @@ class AwaitableResultTupleWrapper(
         Args:
             f: The asynchronous function returning an
                 [collections.abc.Iterable][] to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1050,11 +1156,14 @@ class AwaitableResultTupleWrapper(
             ('failure', 'oops')
         """
         return AwaitableResultTupleWrapper(
-            art.map_successes_to_awaitable_iterable(f)(self.core)
+            art.map_successes_to_awaitable_iterable(f, *args, **kwargs)(self.core)
         )
 
     def map_successes_to_awaitable_result(
-        self, f: Callable[[_S_default_co], AwaitableResult[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResult[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Apply an asynchronous function with return type [trcks.AwaitableResult][]
         to each element in the wrapped [trcks.AwaitableSuccessTuple][].
@@ -1064,6 +1173,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The asynchronous function to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1122,11 +1235,14 @@ class AwaitableResultTupleWrapper(
             ('failure', 'oops')
         """
         return AwaitableResultTupleWrapper(
-            art.map_successes_to_awaitable_result(f)(self.core)
+            art.map_successes_to_awaitable_result(f, *args, **kwargs)(self.core)
         )
 
     def map_successes_to_awaitable_result_iterable(
-        self, f: Callable[[_S_default_co], AwaitableResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Apply an asynchronous function with return type
         [trcks.AwaitableResultIterable][] to each element in the wrapped
@@ -1137,6 +1253,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The asynchronous function to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1195,29 +1315,44 @@ class AwaitableResultTupleWrapper(
             ('failure', 'oops')
         """
         return AwaitableResultTupleWrapper(
-            art.map_successes_to_awaitable_result_iterable(f)(self.core)
+            art.map_successes_to_awaitable_result_iterable(f, *args, **kwargs)(
+                self.core
+            )
         )
 
     @deprecated("Use map_successes_to_awaitable_result_iterable instead")
     def map_successes_to_awaitable_result_tuple(
-        self, f: Callable[[_S_default_co], AwaitableResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.map_successes_to_awaitable_result_iterable][].
         """
-        return self.map_successes_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.map_successes_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_successes_to_awaitable_iterable instead")
     def map_successes_to_awaitable_tuple(
-        self, f: Callable[[_S_default_co], AwaitableTuple[_S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableTuple[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.map_successes_to_awaitable_iterable][].
         """
-        return self.map_successes_to_awaitable_iterable(f)  # pragma: no cover
+        return self.map_successes_to_awaitable_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def map_successes_to_iterable(
-        self, f: Callable[[_S_default_co], Iterable[_S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Iterable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
         """Apply a synchronous function returning an [collections.abc.Iterable][]
         to each element in the wrapped [trcks.AwaitableSuccessTuple][] and flatten.
@@ -1228,6 +1363,10 @@ class AwaitableResultTupleWrapper(
             f: The synchronous function returning an
                 [collections.abc.Iterable][] to be applied to each success
                 element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1253,10 +1392,15 @@ class AwaitableResultTupleWrapper(
             >>> asyncio.run(wrapper_1.core_as_coroutine)
             ('success', (1, 1, 2, 2))
         """
-        return AwaitableResultTupleWrapper(art.map_successes_to_iterable(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.map_successes_to_iterable(f, *args, **kwargs)(self.core)
+        )
 
     def map_successes_to_result(
-        self, f: Callable[[_S_default_co], Result[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Result[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Apply a synchronous function with return type [trcks.Result][]
         to each element in the wrapped [trcks.AwaitableSuccessTuple][].
@@ -1266,6 +1410,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The synchronous function to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1314,10 +1462,15 @@ class AwaitableResultTupleWrapper(
             >>> asyncio.run(wrapper_3.core_as_coroutine)
             ('failure', 'oops')
         """
-        return AwaitableResultTupleWrapper(art.map_successes_to_result(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.map_successes_to_result(f, *args, **kwargs)(self.core)
+        )
 
     def map_successes_to_result_iterable(
-        self, f: Callable[[_S_default_co], ResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Apply a synchronous function with return type [trcks.ResultIterable][]
         to each element in the wrapped [trcks.AwaitableSuccessTuple][] and flatten.
@@ -1327,6 +1480,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The synchronous function to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1366,29 +1523,40 @@ class AwaitableResultTupleWrapper(
             ('failure', 'oops')
         """
         return AwaitableResultTupleWrapper(
-            art.map_successes_to_result_iterable(f)(self.core)
+            art.map_successes_to_result_iterable(f, *args, **kwargs)(self.core)
         )
 
     @deprecated("Use map_successes_to_result_iterable instead")
     def map_successes_to_result_tuple(
-        self, f: Callable[[_S_default_co], ResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.map_successes_to_result_iterable][].
         """
-        return self.map_successes_to_result_iterable(f)  # pragma: no cover
+        return self.map_successes_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_successes_to_iterable instead")
     def map_successes_to_tuple(
-        self, f: Callable[[_S_default_co], tuple[_S, ...]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], tuple[_S, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.map_successes_to_iterable][].
         """
-        return self.map_successes_to_iterable(f)  # pragma: no cover
+        return self.map_successes_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def tap_failure(
-        self, f: Callable[[_F_default_co], object]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], object],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply a synchronous side effect to the wrapped [trcks.Failure][] object.
 
@@ -1396,6 +1564,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance
@@ -1427,10 +1599,15 @@ class AwaitableResultTupleWrapper(
             >>> result_2
             ('success', (1,))
         """
-        return AwaitableResultTupleWrapper(art.tap_failure(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.tap_failure(f, *args, **kwargs)(self.core)
+        )
 
     def tap_failure_to_awaitable(
-        self, f: Callable[[_F_default_co], Awaitable[object]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Awaitable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply an asynchronous side effect to the wrapped [trcks.Failure][] object.
 
@@ -1438,6 +1615,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance
@@ -1470,10 +1651,15 @@ class AwaitableResultTupleWrapper(
             >>> result_2
             ('success', (1,))
         """
-        return AwaitableResultTupleWrapper(art.tap_failure_to_awaitable(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.tap_failure_to_awaitable(f, *args, **kwargs)(self.core)
+        )
 
     def tap_failure_to_awaitable_iterable(
-        self, f: Callable[[_F_default_co], AwaitableIterable[object]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableIterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Apply an asynchronous side effect returning an
         [collections.abc.Iterable][] to the wrapped [trcks.Failure][] object.
@@ -1487,6 +1673,10 @@ class AwaitableResultTupleWrapper(
         Args:
             f: The asynchronous side effect returning an
                 [collections.abc.Iterable][] to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1536,11 +1726,14 @@ class AwaitableResultTupleWrapper(
         tapped_f: Callable[
             [AwaitableResultTuple[_F_default_co, _S_default_co]],
             AwaitableResultTuple[Never, _F_default_co | _S_default_co],
-        ] = art.tap_failure_to_awaitable_iterable(f)
+        ] = art.tap_failure_to_awaitable_iterable(f, *args, **kwargs)
         return AwaitableResultTupleWrapper(tapped_f(self.core))
 
     def tap_failure_to_awaitable_result(
-        self, f: Callable[[_F_default_co], AwaitableResult[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResult[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Apply an asynchronous side effect with return type [trcks.AwaitableResult][]
         to the wrapped [trcks.Failure][] object.
@@ -1549,6 +1742,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1591,11 +1788,16 @@ class AwaitableResultTupleWrapper(
             ('failure', 'fatal')
         """
         return AwaitableResultTupleWrapper(
-            art.tap_failure_to_awaitable_result(f)(self.core)
+            art.tap_failure_to_awaitable_result(f, *args, **kwargs)(self.core)
         )
 
     def tap_failure_to_awaitable_result_iterable(
-        self, f: Callable[[_F_default_co], AwaitableResultIterable[object, _S]]
+        self,
+        f: Callable[
+            Concatenate[_F_default_co, _P], AwaitableResultIterable[object, _S]
+        ],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Apply an asynchronous side effect with return type
         [trcks.AwaitableResultIterable][] to the wrapped [trcks.Failure][] object.
@@ -1604,6 +1806,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1652,29 +1858,42 @@ class AwaitableResultTupleWrapper(
             ('failure', 'fatal')
         """
         return AwaitableResultTupleWrapper(
-            art.tap_failure_to_awaitable_result_iterable(f)(self.core)
+            art.tap_failure_to_awaitable_result_iterable(f, *args, **kwargs)(self.core)
         )
 
     @deprecated("Use tap_failure_to_awaitable_result_iterable instead")
     def tap_failure_to_awaitable_result_tuple(
-        self, f: Callable[[_F_default_co], AwaitableResultTuple[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResultTuple[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.tap_failure_to_awaitable_result_iterable][].
         """
-        return self.tap_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_failure_to_awaitable_iterable instead")
     def tap_failure_to_awaitable_tuple(
-        self, f: Callable[[_F_default_co], AwaitableTuple[object]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableTuple[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.tap_failure_to_awaitable_iterable][].
         """
-        return self.tap_failure_to_awaitable_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_awaitable_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def tap_failure_to_iterable(
-        self, f: Callable[[_F_default_co], Iterable[object]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Iterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Apply a synchronous side effect returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Failure][] object.
@@ -1688,6 +1907,10 @@ class AwaitableResultTupleWrapper(
         Args:
             f: The synchronous side effect returning an
                 [collections.abc.Iterable][] to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1734,11 +1957,14 @@ class AwaitableResultTupleWrapper(
         tapped_f: Callable[
             [AwaitableResultTuple[_F_default_co, _S_default_co]],
             AwaitableResultTuple[Never, _F_default_co | _S_default_co],
-        ] = art.tap_failure_to_iterable(f)
+        ] = art.tap_failure_to_iterable(f, *args, **kwargs)
         return AwaitableResultTupleWrapper(tapped_f(self.core))
 
     def tap_failure_to_result(
-        self, f: Callable[[_F_default_co], Result[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Result[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Apply a synchronous side effect with return type [trcks.Result][]
         to the wrapped [trcks.Failure][] object.
@@ -1747,6 +1973,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1797,10 +2027,15 @@ class AwaitableResultTupleWrapper(
             >>> asyncio.run(wrapper_3.core_as_coroutine)
             ('success', (1,))
         """
-        return AwaitableResultTupleWrapper(art.tap_failure_to_result(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.tap_failure_to_result(f, *args, **kwargs)(self.core)
+        )
 
     def tap_failure_to_result_iterable(
-        self, f: Callable[[_F_default_co], ResultIterable[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultIterable[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Apply a synchronous side effect with return type [trcks.ResultIterable][]
         to the wrapped [trcks.Failure][] object.
@@ -1809,6 +2044,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1860,29 +2099,40 @@ class AwaitableResultTupleWrapper(
             ('success', (1,))
         """
         return AwaitableResultTupleWrapper(
-            art.tap_failure_to_result_iterable(f)(self.core)
+            art.tap_failure_to_result_iterable(f, *args, **kwargs)(self.core)
         )
 
     @deprecated("Use tap_failure_to_result_iterable instead")
     def tap_failure_to_result_tuple(
-        self, f: Callable[[_F_default_co], ResultTuple[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultTuple[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.tap_failure_to_result_iterable][].
         """
-        return self.tap_failure_to_result_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_failure_to_iterable instead")
     def tap_failure_to_tuple(
-        self, f: Callable[[_F_default_co], tuple[object, ...]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], tuple[object, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.tap_failure_to_iterable][].
         """
-        return self.tap_failure_to_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def tap_successes(
-        self, f: Callable[[_S_default_co], object]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], object],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply a synchronous side effect to each element in the wrapped
         [trcks.AwaitableSuccessTuple][].
@@ -1891,6 +2141,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The synchronous side effect to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance
@@ -1924,10 +2178,15 @@ class AwaitableResultTupleWrapper(
             >>> result_2
             ('failure', 'oops')
         """
-        return AwaitableResultTupleWrapper(art.tap_successes(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.tap_successes(f, *args, **kwargs)(self.core)
+        )
 
     def tap_successes_to_awaitable(
-        self, f: Callable[[_S_default_co], Awaitable[object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Awaitable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply an asynchronous side effect to each element in the wrapped
         [trcks.AwaitableSuccessTuple][].
@@ -1936,6 +2195,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The asynchronous side effect to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance
@@ -1970,10 +2233,15 @@ class AwaitableResultTupleWrapper(
             >>> result_2
             ('failure', 'oops')
         """
-        return AwaitableResultTupleWrapper(art.tap_successes_to_awaitable(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.tap_successes_to_awaitable(f, *args, **kwargs)(self.core)
+        )
 
     def tap_successes_to_awaitable_iterable(
-        self, f: Callable[[_S_default_co], AwaitableIterable[object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableIterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply an asynchronous side effect returning an
         [collections.abc.Iterable][] to each element in the wrapped
@@ -1987,6 +2255,10 @@ class AwaitableResultTupleWrapper(
         Args:
             f: The asynchronous side effect returning an
                 [collections.abc.Iterable][] to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -2018,11 +2290,14 @@ class AwaitableResultTupleWrapper(
             ('success', (7, 7))
         """
         return AwaitableResultTupleWrapper(
-            art.tap_successes_to_awaitable_iterable(f)(self.core)
+            art.tap_successes_to_awaitable_iterable(f, *args, **kwargs)(self.core)
         )
 
     def tap_successes_to_awaitable_result(
-        self, f: Callable[[_S_default_co], AwaitableResult[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResult[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Apply an asynchronous side effect with return type [trcks.AwaitableResult][]
         to each element in the wrapped [trcks.AwaitableSuccessTuple][].
@@ -2031,6 +2306,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The asynchronous side effect to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -2082,11 +2361,16 @@ class AwaitableResultTupleWrapper(
             ('failure', 'oops')
         """
         return AwaitableResultTupleWrapper(
-            art.tap_successes_to_awaitable_result(f)(self.core)
+            art.tap_successes_to_awaitable_result(f, *args, **kwargs)(self.core)
         )
 
     def tap_successes_to_awaitable_result_iterable(
-        self, f: Callable[[_S_default_co], AwaitableResultIterable[_F, object]]
+        self,
+        f: Callable[
+            Concatenate[_S_default_co, _P], AwaitableResultIterable[_F, object]
+        ],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Apply an asynchronous side effect with return type
         [trcks.AwaitableResultIterable][] to each element in the wrapped
@@ -2096,6 +2380,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The asynchronous side effect to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -2148,29 +2436,44 @@ class AwaitableResultTupleWrapper(
             ('failure', 'oops')
         """
         return AwaitableResultTupleWrapper(
-            art.tap_successes_to_awaitable_result_iterable(f)(self.core)
+            art.tap_successes_to_awaitable_result_iterable(f, *args, **kwargs)(
+                self.core
+            )
         )
 
     @deprecated("Use tap_successes_to_awaitable_result_iterable instead")
     def tap_successes_to_awaitable_result_tuple(
-        self, f: Callable[[_S_default_co], AwaitableResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.tap_successes_to_awaitable_result_iterable][].
         """
-        return self.tap_successes_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.tap_successes_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_successes_to_awaitable_iterable instead")
     def tap_successes_to_awaitable_tuple(
-        self, f: Callable[[_S_default_co], AwaitableTuple[object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableTuple[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.tap_successes_to_awaitable_iterable][].
         """
-        return self.tap_successes_to_awaitable_iterable(f)  # pragma: no cover
+        return self.tap_successes_to_awaitable_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def tap_successes_to_iterable(
-        self, f: Callable[[_S_default_co], Iterable[object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Iterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply a synchronous side effect returning an [collections.abc.Iterable][]
         to each element in the wrapped [trcks.AwaitableSuccessTuple][].
@@ -2184,6 +2487,10 @@ class AwaitableResultTupleWrapper(
             f: The synchronous side effect returning an
                 [collections.abc.Iterable][] to be applied
                 to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -2212,10 +2519,15 @@ class AwaitableResultTupleWrapper(
             >>> result_1
             ('success', (7, 7))
         """
-        return AwaitableResultTupleWrapper(art.tap_successes_to_iterable(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.tap_successes_to_iterable(f, *args, **kwargs)(self.core)
+        )
 
     def tap_successes_to_result(
-        self, f: Callable[[_S_default_co], Result[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Result[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Apply a synchronous side effect with return type [trcks.Result][]
         to each element in the wrapped [trcks.AwaitableSuccessTuple][].
@@ -2224,6 +2536,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The synchronous side effect to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -2273,10 +2589,15 @@ class AwaitableResultTupleWrapper(
             >>> asyncio.run(wrapper_3.core_as_coroutine)
             ('failure', 'oops')
         """
-        return AwaitableResultTupleWrapper(art.tap_successes_to_result(f)(self.core))
+        return AwaitableResultTupleWrapper(
+            art.tap_successes_to_result(f, *args, **kwargs)(self.core)
+        )
 
     def tap_successes_to_result_iterable(
-        self, f: Callable[[_S_default_co], ResultIterable[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultIterable[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Apply a synchronous side effect with return type [trcks.ResultIterable][]
         to each element in the wrapped [trcks.AwaitableSuccessTuple][].
@@ -2285,6 +2606,10 @@ class AwaitableResultTupleWrapper(
 
         Args:
             f: The synchronous side effect to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -2336,23 +2661,31 @@ class AwaitableResultTupleWrapper(
             ('failure', 'oops')
         """
         return AwaitableResultTupleWrapper(
-            art.tap_successes_to_result_iterable(f)(self.core)
+            art.tap_successes_to_result_iterable(f, *args, **kwargs)(self.core)
         )
 
     @deprecated("Use tap_successes_to_result_iterable instead")
     def tap_successes_to_result_tuple(
-        self, f: Callable[[_S_default_co], ResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.tap_successes_to_result_iterable][].
         """
-        return self.tap_successes_to_result_iterable(f)  # pragma: no cover
+        return self.tap_successes_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_successes_to_iterable instead")
     def tap_successes_to_tuple(
-        self, f: Callable[[_S_default_co], tuple[object, ...]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], tuple[object, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultTupleWrapper.tap_successes_to_iterable][].
         """
-        return self.tap_successes_to_iterable(f)  # pragma: no cover
+        return self.tap_successes_to_iterable(f, *args, **kwargs)  # pragma: no cover

--- a/src/trcks/oop/_awaitable_result_wrapper.py
+++ b/src/trcks/oop/_awaitable_result_wrapper.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, Concatenate, ParamSpec, final
 
 from trcks import Result
 from trcks._typing import Never, TypeVar, deprecated
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 __docformat__ = "google"
 
 _F = TypeVar("_F")
+_P = ParamSpec("_P")
 _S = TypeVar("_S")
 
 _F_default = TypeVar("_F_default", default=Never)
@@ -248,7 +249,10 @@ class AwaitableResultWrapper(
         return AwaitableResultWrapper(ar.construct_success_from_awaitable(awtbl))
 
     def map_failure(
-        self, f: Callable[[_F_default_co], _F]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], _F],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F, _S_default_co]:
         """Apply a synchronous function to the wrapped [trcks.Failure][] object.
 
@@ -256,6 +260,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance with
@@ -287,10 +295,13 @@ class AwaitableResultWrapper(
             >>> asyncio.run(awaitable_result_wrapper_2.core_as_coroutine)
             ('success', 25.0)
         """
-        return AwaitableResultWrapper(ar.map_failure(f)(self.core))
+        return AwaitableResultWrapper(ar.map_failure(f, *args, **kwargs)(self.core))
 
     def map_failure_to_awaitable(
-        self, f: Callable[[_F_default_co], Awaitable[_F]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Awaitable[_F]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F, _S_default_co]:
         """Apply an asynchronous function to the wrapped [trcks.Failure][] object.
 
@@ -298,6 +309,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance with
@@ -333,10 +348,15 @@ class AwaitableResultWrapper(
             >>> asyncio.run(awaitable_result_wrapper_2.core_as_coroutine)
             ('success', 42)
         """
-        return AwaitableResultWrapper(ar.map_failure_to_awaitable(f)(self.core))
+        return AwaitableResultWrapper(
+            ar.map_failure_to_awaitable(f, *args, **kwargs)(self.core)
+        )
 
     def map_failure_to_awaitable_result(
-        self, f: Callable[[_F_default_co], AwaitableResult[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResult[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F, _S_default_co | _S]:
         """Apply an asynchronous function with return type [trcks.Result][]
         to the wrapped [trcks.Failure][] object.
@@ -345,6 +365,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance with
@@ -393,10 +417,15 @@ class AwaitableResultWrapper(
             >>> asyncio.run(awaitable_result_wrapper_3.core_as_coroutine)
             ('success', 25.0)
         """
-        return AwaitableResultWrapper(ar.map_failure_to_awaitable_result(f)(self.core))
+        return AwaitableResultWrapper(
+            ar.map_failure_to_awaitable_result(f, *args, **kwargs)(self.core)
+        )
 
     def map_failure_to_awaitable_result_iterable(
-        self, f: Callable[[_F_default_co], AwaitableResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Apply an asynchronous function with return type
         [trcks.AwaitableResultIterable][] to the wrapped [trcks.Failure][] object.
@@ -405,6 +434,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -447,19 +480,27 @@ class AwaitableResultWrapper(
         """
         return AwaitableResultTupleWrapper.construct_from_awaitable_result(
             self.core
-        ).map_failure_to_awaitable_result_iterable(f)
+        ).map_failure_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_failure_to_awaitable_result_iterable instead")
     def map_failure_to_awaitable_result_tuple(
-        self, f: Callable[[_F_default_co], AwaitableResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultWrapper.map_failure_to_awaitable_result_iterable][].
         """
-        return self.map_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.map_failure_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def map_failure_to_iterable(
-        self, f: Callable[[_F_default_co], Iterable[_S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Iterable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
         """Apply a synchronous function returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Failure][] object.
@@ -470,6 +511,10 @@ class AwaitableResultWrapper(
         Args:
             f: The synchronous function to be applied,
                 returning an [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -509,10 +554,13 @@ class AwaitableResultWrapper(
         """
         return AwaitableResultTupleWrapper.construct_from_awaitable_result(
             self.core
-        ).map_failure_to_iterable(f)
+        ).map_failure_to_iterable(f, *args, **kwargs)
 
     def map_failure_to_result(
-        self, f: Callable[[_F_default_co], Result[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Result[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F, _S_default_co | _S]:
         """Apply a synchronous function with return type [trcks.Result][]
         to the wrapped [trcks.Failure][] object.
@@ -521,6 +569,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance with
@@ -568,10 +620,15 @@ class AwaitableResultWrapper(
             >>> asyncio.run(awaitable_result_wrapper_3.core_as_coroutine)
             ('success', 25.0)
         """
-        return AwaitableResultWrapper(ar.map_failure_to_result(f)(self.core))
+        return AwaitableResultWrapper(
+            ar.map_failure_to_result(f, *args, **kwargs)(self.core)
+        )
 
     def map_failure_to_result_iterable(
-        self, f: Callable[[_F_default_co], ResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Apply a synchronous function with return type [trcks.ResultIterable][]
         to the wrapped [trcks.Failure][] object.
@@ -580,6 +637,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -619,28 +680,39 @@ class AwaitableResultWrapper(
         """
         return AwaitableResultTupleWrapper.construct_from_awaitable_result(
             self.core
-        ).map_failure_to_result_iterable(f)
+        ).map_failure_to_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_failure_to_result_iterable instead")
     def map_failure_to_result_tuple(
-        self, f: Callable[[_F_default_co], ResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultWrapper.map_failure_to_result_iterable][].
         """
-        return self.map_failure_to_result_iterable(f)  # pragma: no cover
+        return self.map_failure_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_failure_to_iterable instead")
     def map_failure_to_tuple(
-        self, f: Callable[[_F_default_co], tuple[_S, ...]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], tuple[_S, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultWrapper.map_failure_to_iterable][].
         """
-        return self.map_failure_to_iterable(f)  # pragma: no cover
+        return self.map_failure_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def map_success(
-        self, f: Callable[[_S_default_co], _S]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], _S],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co, _S]:
         """Apply a synchronous function to the wrapped [trcks.Success][] object.
 
@@ -648,6 +720,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance with
@@ -680,10 +756,13 @@ class AwaitableResultWrapper(
             >>> asyncio.run(awaitable_result_wrapper_2.core_as_coroutine)
             ('success', 43)
         """
-        return AwaitableResultWrapper(ar.map_success(f)(self.core))
+        return AwaitableResultWrapper(ar.map_success(f, *args, **kwargs)(self.core))
 
     def map_success_to_awaitable(
-        self, f: Callable[[_S_default_co], Awaitable[_S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Awaitable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co, _S]:
         """Apply an asynchronous function to the wrapped [trcks.Success][] object.
 
@@ -691,6 +770,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance with
@@ -726,10 +809,15 @@ class AwaitableResultWrapper(
             >>> asyncio.run(awaitable_result_wrapper_2.core_as_coroutine)
             ('success', 43)
         """
-        return AwaitableResultWrapper(ar.map_success_to_awaitable(f)(self.core))
+        return AwaitableResultWrapper(
+            ar.map_success_to_awaitable(f, *args, **kwargs)(self.core)
+        )
 
     def map_success_to_awaitable_result(
-        self, f: Callable[[_S_default_co], AwaitableResult[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResult[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co | _F, _S]:
         """Apply an asynchronous function with return type [trcks.Result][]
         to the wrapped [trcks.Success][] object.
@@ -738,6 +826,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance with
@@ -787,10 +879,15 @@ class AwaitableResultWrapper(
             >>> asyncio.run(awaitable_result_wrapper_3.core_as_coroutine)
             ('success', 5.0)
         """
-        return AwaitableResultWrapper(ar.map_success_to_awaitable_result(f)(self.core))
+        return AwaitableResultWrapper(
+            ar.map_success_to_awaitable_result(f, *args, **kwargs)(self.core)
+        )
 
     def map_success_to_awaitable_result_iterable(
-        self, f: Callable[[_S_default_co], AwaitableResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Apply an asynchronous function with return type
         [trcks.AwaitableResultIterable][] to the wrapped [trcks.Success][] object.
@@ -799,6 +896,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -841,19 +942,27 @@ class AwaitableResultWrapper(
         """
         return AwaitableResultTupleWrapper.construct_from_awaitable_result(
             self.core
-        ).map_successes_to_awaitable_result_iterable(f)
+        ).map_successes_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_success_to_awaitable_result_iterable instead")
     def map_success_to_awaitable_result_tuple(
-        self, f: Callable[[_S_default_co], AwaitableResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultWrapper.map_success_to_awaitable_result_iterable][].
         """
-        return self.map_success_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.map_success_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def map_success_to_iterable(
-        self, f: Callable[[_S_default_co], Iterable[_S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Iterable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
         """Apply a synchronous function returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Success][] object.
@@ -863,6 +972,10 @@ class AwaitableResultWrapper(
         Args:
             f: The synchronous function to be applied,
                 returning an [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -900,10 +1013,13 @@ class AwaitableResultWrapper(
         """
         return AwaitableResultTupleWrapper.construct_from_awaitable_result(
             self.core
-        ).map_successes_to_iterable(f)
+        ).map_successes_to_iterable(f, *args, **kwargs)
 
     def map_success_to_result(
-        self, f: Callable[[_S_default_co], Result[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Result[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co | _F, _S]:
         """Apply a synchronous function with return type [trcks.Result][]
         to the wrapped [trcks.Success][] object.
@@ -912,6 +1028,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance with
@@ -960,10 +1080,15 @@ class AwaitableResultWrapper(
             >>> asyncio.run(awaitable_result_3.core_as_coroutine)
             ('success', 5.0)
         """
-        return AwaitableResultWrapper(ar.map_success_to_result(f)(self.core))
+        return AwaitableResultWrapper(
+            ar.map_success_to_result(f, *args, **kwargs)(self.core)
+        )
 
     def map_success_to_result_iterable(
-        self, f: Callable[[_S_default_co], ResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Apply a synchronous function with return type [trcks.ResultIterable][]
         to the wrapped [trcks.Success][] object.
@@ -972,6 +1097,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1011,28 +1140,39 @@ class AwaitableResultWrapper(
         """
         return AwaitableResultTupleWrapper.construct_from_awaitable_result(
             self.core
-        ).map_successes_to_result_iterable(f)
+        ).map_successes_to_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_success_to_result_iterable instead")
     def map_success_to_result_tuple(
-        self, f: Callable[[_S_default_co], ResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultWrapper.map_success_to_result_iterable][].
         """
-        return self.map_success_to_result_iterable(f)  # pragma: no cover
+        return self.map_success_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_success_to_iterable instead")
     def map_success_to_tuple(
-        self, f: Callable[[_S_default_co], tuple[_S, ...]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], tuple[_S, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultWrapper.map_success_to_iterable][].
         """
-        return self.map_success_to_iterable(f)  # pragma: no cover
+        return self.map_success_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def tap_failure(
-        self, f: Callable[[_F_default_co], object]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], object],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co, _S_default_co]:
         """Apply a synchronous side effect to the wrapped [trcks.Failure][] object.
 
@@ -1040,6 +1180,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance
@@ -1067,10 +1211,13 @@ class AwaitableResultWrapper(
             >>> result_2
             ('success', 42)
         """
-        return AwaitableResultWrapper(ar.tap_failure(f)(self.core))
+        return AwaitableResultWrapper(ar.tap_failure(f, *args, **kwargs)(self.core))
 
     def tap_failure_to_awaitable(
-        self, f: Callable[[_F_default_co], Awaitable[object]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Awaitable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co, _S_default_co]:
         """Apply an asynchronous side effect to the wrapped [trcks.Failure][] object.
 
@@ -1078,6 +1225,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance
@@ -1109,10 +1260,15 @@ class AwaitableResultWrapper(
             >>> result_2
             ('success', 42)
         """
-        return AwaitableResultWrapper(ar.tap_failure_to_awaitable(f)(self.core))
+        return AwaitableResultWrapper(
+            ar.tap_failure_to_awaitable(f, *args, **kwargs)(self.core)
+        )
 
     def tap_failure_to_awaitable_result(
-        self, f: Callable[[_F_default_co], AwaitableResult[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResult[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co, _S_default_co | _S]:
         """Apply an asynchronous side effect with return type [trcks.Result][]
         to the wrapped [trcks.Failure][] object.
@@ -1121,6 +1277,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance with
@@ -1131,10 +1291,17 @@ class AwaitableResultWrapper(
                     if the applied side effect returns a [trcks.Success][] and
                 - *the original* [trcks.Success][] if no side effect was applied.
         """
-        return AwaitableResultWrapper(ar.tap_failure_to_awaitable_result(f)(self.core))
+        return AwaitableResultWrapper(
+            ar.tap_failure_to_awaitable_result(f, *args, **kwargs)(self.core)
+        )
 
     def tap_failure_to_awaitable_result_iterable(
-        self, f: Callable[[_F_default_co], AwaitableResultIterable[object, _S]]
+        self,
+        f: Callable[
+            Concatenate[_F_default_co, _P], AwaitableResultIterable[object, _S]
+        ],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Apply an asynchronous side effect with return type
         [trcks.AwaitableResultIterable][] to the wrapped [trcks.Failure][] object.
@@ -1143,6 +1310,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1188,19 +1359,27 @@ class AwaitableResultWrapper(
         """
         return AwaitableResultTupleWrapper.construct_from_awaitable_result(
             self.core
-        ).tap_failure_to_awaitable_result_iterable(f)
+        ).tap_failure_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_failure_to_awaitable_result_iterable instead")
     def tap_failure_to_awaitable_result_tuple(
-        self, f: Callable[[_F_default_co], AwaitableResultTuple[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResultTuple[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultWrapper.tap_failure_to_awaitable_result_iterable][].
         """
-        return self.tap_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def tap_failure_to_iterable(
-        self, f: Callable[[_F_default_co], Iterable[object]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Iterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Apply a synchronous side effect returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Failure][] object.
@@ -1213,6 +1392,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1255,10 +1438,13 @@ class AwaitableResultWrapper(
         """
         return AwaitableResultTupleWrapper.construct_from_awaitable_result(
             self.core
-        ).tap_failure_to_iterable(f)
+        ).tap_failure_to_iterable(f, *args, **kwargs)
 
     def tap_failure_to_result(
-        self, f: Callable[[_F_default_co], Result[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Result[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co, _S_default_co | _S]:
         """Apply a synchronous side effect with return type [trcks.Result][]
         to the wrapped [trcks.Failure][] object.
@@ -1267,6 +1453,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance with
@@ -1316,10 +1506,15 @@ class AwaitableResultWrapper(
             >>> asyncio.run(awaitable_result_wrapper_3.core_as_coroutine)
             ('success', 42)
         """
-        return AwaitableResultWrapper(ar.tap_failure_to_result(f)(self.core))
+        return AwaitableResultWrapper(
+            ar.tap_failure_to_result(f, *args, **kwargs)(self.core)
+        )
 
     def tap_failure_to_result_iterable(
-        self, f: Callable[[_F_default_co], ResultIterable[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultIterable[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Apply a synchronous side effect with return type [trcks.ResultIterable][]
         to the wrapped [trcks.Failure][] object.
@@ -1328,6 +1523,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1370,28 +1569,39 @@ class AwaitableResultWrapper(
         """
         return AwaitableResultTupleWrapper.construct_from_awaitable_result(
             self.core
-        ).tap_failure_to_result_iterable(f)
+        ).tap_failure_to_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_failure_to_result_iterable instead")
     def tap_failure_to_result_tuple(
-        self, f: Callable[[_F_default_co], ResultTuple[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultTuple[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultWrapper.tap_failure_to_result_iterable][].
         """
-        return self.tap_failure_to_result_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_failure_to_iterable instead")
     def tap_failure_to_tuple(
-        self, f: Callable[[_F_default_co], tuple[object, ...]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], tuple[object, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultWrapper.tap_failure_to_iterable][].
         """
-        return self.tap_failure_to_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def tap_success(
-        self, f: Callable[[_S_default_co], object]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], object],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co, _S_default_co]:
         """Apply a synchronous side effect to the wrapped [trcks.Success][] object.
 
@@ -1399,6 +1609,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance
@@ -1426,10 +1640,13 @@ class AwaitableResultWrapper(
             >>> result_2
             ('success', 42)
         """
-        return AwaitableResultWrapper(ar.tap_success(f)(self.core))
+        return AwaitableResultWrapper(ar.tap_success(f, *args, **kwargs)(self.core))
 
     def tap_success_to_awaitable(
-        self, f: Callable[[_S_default_co], Awaitable[object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Awaitable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co, _S_default_co]:
         """Apply an asynchronous side effect to the wrapped [trcks.Success][] object.
 
@@ -1437,6 +1654,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance
@@ -1468,10 +1689,15 @@ class AwaitableResultWrapper(
             >>> result_2
             ('success', 'Hello, world!')
         """
-        return AwaitableResultWrapper(ar.tap_success_to_awaitable(f)(self.core))
+        return AwaitableResultWrapper(
+            ar.tap_success_to_awaitable(f, *args, **kwargs)(self.core)
+        )
 
     def tap_success_to_awaitable_result(
-        self, f: Callable[[_S_default_co], AwaitableResult[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResult[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co | _F, _S_default_co]:
         """Apply an asynchronous side effect with return type [trcks.Result][]
         to the wrapped [trcks.Success][] object.
@@ -1480,6 +1706,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance with
@@ -1543,10 +1773,17 @@ class AwaitableResultWrapper(
             >>> result_4
             ('success', 'Hello, world!')
         """
-        return AwaitableResultWrapper(ar.tap_success_to_awaitable_result(f)(self.core))
+        return AwaitableResultWrapper(
+            ar.tap_success_to_awaitable_result(f, *args, **kwargs)(self.core)
+        )
 
     def tap_success_to_awaitable_result_iterable(
-        self, f: Callable[[_S_default_co], AwaitableResultIterable[_F, object]]
+        self,
+        f: Callable[
+            Concatenate[_S_default_co, _P], AwaitableResultIterable[_F, object]
+        ],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Apply an asynchronous side effect with return type
         [trcks.AwaitableResultIterable][] to the wrapped [trcks.Success][] object.
@@ -1555,6 +1792,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1601,19 +1842,27 @@ class AwaitableResultWrapper(
         """
         return AwaitableResultTupleWrapper.construct_from_awaitable_result(
             self.core
-        ).tap_successes_to_awaitable_result_iterable(f)
+        ).tap_successes_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_success_to_awaitable_result_iterable instead")
     def tap_success_to_awaitable_result_tuple(
-        self, f: Callable[[_S_default_co], AwaitableResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultWrapper.tap_success_to_awaitable_result_iterable][].
         """
-        return self.tap_success_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.tap_success_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def tap_success_to_iterable(
-        self, f: Callable[[_S_default_co], Iterable[object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Iterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply a synchronous side effect returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Success][] object.
@@ -1626,6 +1875,10 @@ class AwaitableResultWrapper(
         Args:
             f: The synchronous side effect to be applied,
                 returning an [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1668,10 +1921,13 @@ class AwaitableResultWrapper(
         """
         return AwaitableResultTupleWrapper.construct_from_awaitable_result(
             self.core
-        ).tap_successes_to_iterable(f)
+        ).tap_successes_to_iterable(f, *args, **kwargs)
 
     def tap_success_to_result(
-        self, f: Callable[[_S_default_co], Result[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Result[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co | _F, _S_default_co]:
         """Apply a synchronous side effect with return type [trcks.Result][]
         to the wrapped [trcks.Success][] object.
@@ -1680,6 +1936,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultWrapper][] instance with
@@ -1690,10 +1950,15 @@ class AwaitableResultWrapper(
                 - *the original* [trcks.Success][]
                     if the applied side effect returns a [trcks.Success][].
         """
-        return AwaitableResultWrapper(ar.tap_success_to_result(f)(self.core))
+        return AwaitableResultWrapper(
+            ar.tap_success_to_result(f, *args, **kwargs)(self.core)
+        )
 
     def tap_success_to_result_iterable(
-        self, f: Callable[[_S_default_co], ResultIterable[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultIterable[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Apply a synchronous side effect with return type [trcks.ResultIterable][]
         to the wrapped [trcks.Success][] object.
@@ -1702,6 +1967,10 @@ class AwaitableResultWrapper(
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1744,22 +2013,30 @@ class AwaitableResultWrapper(
         """
         return AwaitableResultTupleWrapper.construct_from_awaitable_result(
             self.core
-        ).tap_successes_to_result_iterable(f)
+        ).tap_successes_to_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_success_to_result_iterable instead")
     def tap_success_to_result_tuple(
-        self, f: Callable[[_S_default_co], ResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultWrapper.tap_success_to_result_iterable][].
         """
-        return self.tap_success_to_result_iterable(f)  # pragma: no cover
+        return self.tap_success_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_success_to_iterable instead")
     def tap_success_to_tuple(
-        self, f: Callable[[_S_default_co], tuple[object, ...]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], tuple[object, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableResultWrapper.tap_success_to_iterable][].
         """
-        return self.tap_success_to_iterable(f)  # pragma: no cover
+        return self.tap_success_to_iterable(f, *args, **kwargs)  # pragma: no cover

--- a/src/trcks/oop/_awaitable_tuple_wrapper.py
+++ b/src/trcks/oop/_awaitable_tuple_wrapper.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, Concatenate, ParamSpec, final
 
 from trcks._typing import TypeVar, deprecated
 from trcks.fp.monads import awaitable_tuple as at
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 __docformat__ = "google"
 
+_P = ParamSpec("_P")
 _T = TypeVar("_T")
 
 _T_co = TypeVar("_T_co", covariant=True)
@@ -172,12 +173,21 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
         """Deprecated alias for construct_from_iterable."""
         return cls.construct_from_iterable(tpl)  # pragma: no cover
 
-    def map(self, f: Callable[[_T_co], _T]) -> AwaitableTupleWrapper[_T]:
+    def map(
+        self,
+        f: Callable[Concatenate[_T_co, _P], _T],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> AwaitableTupleWrapper[_T]:
         """Apply a synchronous function to each element in the wrapped
         [trcks.AwaitableTuple][] object.
 
         Args:
             f: The synchronous function to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -200,16 +210,23 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
             >>> asyncio.run(awaitable_tuple_wrapper.core_as_coroutine)
             (2, 4, 6)
         """
-        return AwaitableTupleWrapper(at.map_(f)(self.core))
+        return AwaitableTupleWrapper(at.map_(f, *args, **kwargs)(self.core))
 
     def map_to_awaitable(
-        self, f: Callable[[_T_co], Awaitable[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Awaitable[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Apply an asynchronous function to each element in the wrapped
         [trcks.AwaitableTuple][] object.
 
         Args:
             f: The asynchronous function to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -233,10 +250,13 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
             >>> asyncio.run(awaitable_tuple_wrapper.core_as_coroutine)
             (2, 3)
         """
-        return AwaitableTupleWrapper(at.map_to_awaitable(f)(self.core))
+        return AwaitableTupleWrapper(at.map_to_awaitable(f, *args, **kwargs)(self.core))
 
     def map_to_awaitable_iterable(
-        self, f: Callable[[_T_co], AwaitableIterable[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableIterable[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Apply an asynchronous function returning a [trcks.AwaitableIterable][]
         to each element in the wrapped [trcks.AwaitableTuple][] and flatten.
@@ -244,6 +264,10 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
         Args:
             f: The asynchronous function to be applied to each element,
                 returning a [trcks.AwaitableIterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -266,19 +290,27 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
             >>> asyncio.run(awaitable_tuple_wrapper.core_as_coroutine)
             (1, 1, 2, 2)
         """
-        return AwaitableTupleWrapper(at.map_to_awaitable_iterable(f)(self.core))
+        return AwaitableTupleWrapper(
+            at.map_to_awaitable_iterable(f, *args, **kwargs)(self.core)
+        )
 
     @deprecated("Use map_to_awaitable_iterable instead")
     def map_to_awaitable_tuple(
-        self, f: Callable[[_T_co], AwaitableTuple[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableTuple[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Deprecated alias for
         [trcks.oop.AwaitableTupleWrapper.map_to_awaitable_iterable][].
         """
-        return self.map_to_awaitable_iterable(f)  # pragma: no cover
+        return self.map_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def map_to_iterable(
-        self, f: Callable[[_T_co], Iterable[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Iterable[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Apply a synchronous function returning an [collections.abc.Iterable][]
         to each element in the wrapped [trcks.AwaitableTuple][] object and flatten.
@@ -286,6 +318,10 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
         Args:
             f: The synchronous function to be applied to each element,
                 returning an [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -307,23 +343,35 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
             >>> asyncio.run(awaitable_tuple_wrapper.core_as_coroutine)
             (1, -1, 2, -2)
         """
-        return AwaitableTupleWrapper(at.map_to_iterable(f)(self.core))
+        return AwaitableTupleWrapper(at.map_to_iterable(f, *args, **kwargs)(self.core))
 
     @deprecated("Use map_to_iterable instead")
     def map_to_tuple(
-        self, f: Callable[[_T_co], tuple[_T, ...]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], tuple[_T, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Deprecated alias for
         [trcks.oop.AwaitableTupleWrapper.map_to_iterable][].
         """
-        return self.map_to_iterable(f)  # pragma: no cover
+        return self.map_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
-    def tap(self, f: Callable[[_T_co], object]) -> AwaitableTupleWrapper[_T_co]:
+    def tap(
+        self,
+        f: Callable[Concatenate[_T_co, _P], object],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> AwaitableTupleWrapper[_T_co]:
         """Apply a synchronous side effect to each element in the wrapped
         [trcks.AwaitableTuple][] object.
 
         Args:
             f: The synchronous side effect to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -347,16 +395,23 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
             Received: 2
             (1, 2)
         """
-        return AwaitableTupleWrapper(at.tap(f)(self.core))
+        return AwaitableTupleWrapper(at.tap(f, *args, **kwargs)(self.core))
 
     def tap_to_awaitable(
-        self, f: Callable[[_T_co], Awaitable[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Awaitable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Apply an asynchronous side effect to each element in the wrapped
         [trcks.AwaitableTuple][] object.
 
         Args:
             f: The asynchronous side effect to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -381,10 +436,13 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
             Logged: 2
             (1, 2)
         """
-        return AwaitableTupleWrapper(at.tap_to_awaitable(f)(self.core))
+        return AwaitableTupleWrapper(at.tap_to_awaitable(f, *args, **kwargs)(self.core))
 
     def tap_to_awaitable_iterable(
-        self, f: Callable[[_T_co], AwaitableIterable[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableIterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Apply an asynchronous side effect returning a [trcks.AwaitableIterable][]
         to each element in the wrapped [trcks.AwaitableTuple][] object.
@@ -392,6 +450,10 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
         Args:
             f: The asynchronous side effect to be applied to each element,
                 returning a [trcks.AwaitableIterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -415,19 +477,27 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
             >>> asyncio.run(awaitable_tuple_wrapper.core_as_coroutine)
             (1, 2, 2, 3, 3, 4, 4, 4)
         """
-        return AwaitableTupleWrapper(at.tap_to_awaitable_iterable(f)(self.core))
+        return AwaitableTupleWrapper(
+            at.tap_to_awaitable_iterable(f, *args, **kwargs)(self.core)
+        )
 
     @deprecated("Use tap_to_awaitable_iterable instead")
     def tap_to_awaitable_tuple(
-        self, f: Callable[[_T_co], AwaitableTuple[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableTuple[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableTupleWrapper.tap_to_awaitable_iterable][].
         """
-        return self.tap_to_awaitable_iterable(f)  # pragma: no cover
+        return self.tap_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def tap_to_iterable(
-        self, f: Callable[[_T_co], Iterable[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Iterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Apply a synchronous side effect returning an [collections.abc.Iterable][]
         to each element in the wrapped [trcks.AwaitableTuple][] object.
@@ -435,6 +505,10 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
         Args:
             f: The synchronous side effect to be applied to each element,
                 returning an [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -457,13 +531,16 @@ class AwaitableTupleWrapper(BaseAwaitableWrapper[tuple[_T_co, ...]]):
             >>> asyncio.run(awaitable_tuple_wrapper.core_as_coroutine)
             (1, 2, 2, 3, 3, 4, 4, 4)
         """
-        return AwaitableTupleWrapper(at.tap_to_iterable(f)(self.core))
+        return AwaitableTupleWrapper(at.tap_to_iterable(f, *args, **kwargs)(self.core))
 
     @deprecated("Use tap_to_iterable instead")
     def tap_to_tuple(
-        self, f: Callable[[_T_co], tuple[object, ...]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], tuple[object, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableTupleWrapper.tap_to_iterable][].
         """
-        return self.tap_to_iterable(f)  # pragma: no cover
+        return self.tap_to_iterable(f, *args, **kwargs)  # pragma: no cover

--- a/src/trcks/oop/_awaitable_wrapper.py
+++ b/src/trcks/oop/_awaitable_wrapper.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, Concatenate, ParamSpec, final
 
 from trcks._typing import TypeVar, deprecated
 from trcks.fp.monads import awaitable as a
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 __docformat__ = "google"
 
 _F = TypeVar("_F")
+_P = ParamSpec("_P")
 _S = TypeVar("_S")
 _T = TypeVar("_T")
 
@@ -127,12 +128,21 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         """
         return AwaitableWrapper(awtbl)
 
-    def map(self, f: Callable[[_T_co], _T]) -> AwaitableWrapper[_T]:
+    def map(
+        self,
+        f: Callable[Concatenate[_T_co, _P], _T],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> AwaitableWrapper[_T]:
         """Apply a synchronous function
         to the wrapped [collections.abc.Awaitable][] object.
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableWrapper][] instance with
@@ -154,16 +164,23 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
             >>> asyncio.run(awaitable_wrapper.core_as_coroutine)
             'Length: 13'
         """
-        return AwaitableWrapper(a.map_(f)(self.core))
+        return AwaitableWrapper(a.map_(f, *args, **kwargs)(self.core))
 
     def map_to_awaitable(
-        self, f: Callable[[_T_co], Awaitable[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Awaitable[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableWrapper[_T]:
         """Apply an asynchronous function
         to the wrapped [collections.abc.Awaitable][] object.
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableWrapper][] instance with
@@ -186,10 +203,13 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
             >>> asyncio.run(awaitable_wrapper.core_as_coroutine)
             Wrote 'Hello, world!' to disk.
         """
-        return AwaitableWrapper(a.map_to_awaitable(f)(self.core))
+        return AwaitableWrapper(a.map_to_awaitable(f, *args, **kwargs)(self.core))
 
     def map_to_awaitable_iterable(
-        self, f: Callable[[_T_co], AwaitableIterable[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableIterable[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Apply an asynchronous function returning an [collections.abc.Iterable][]
         to the wrapped [collections.abc.Awaitable][] object.
@@ -197,6 +217,10 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         Args:
             f: The asynchronous function to be applied, returning an awaitable
                 [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -219,16 +243,25 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
             >>> asyncio.run(awaitable_tuple_wrapper.core_as_coroutine)
             (21, 21)
         """
-        return AwaitableTupleWrapper(a.map_(tuple)(a.map_to_awaitable(f)(self.core)))
+        return AwaitableTupleWrapper(
+            a.map_(tuple)(a.map_to_awaitable(f, *args, **kwargs)(self.core))
+        )
 
     def map_to_awaitable_result(
-        self, f: Callable[[_T_co], AwaitableResult[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResult[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F, _S]:
         """Apply an asynchronous function with return type [trcks.Result][]
         to the wrapped [collections.abc.Awaitable][] object.
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance with
@@ -258,10 +291,13 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         """
         return AwaitableResultWrapper.construct_success_from_awaitable(
             self.core
-        ).map_success_to_awaitable_result(f)
+        ).map_success_to_awaitable_result(f, *args, **kwargs)
 
     def map_to_awaitable_result_iterable(
-        self, f: Callable[[_T_co], AwaitableResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S]:
         """Apply an asynchronous function with return type
         [trcks.AwaitableResultIterable][] to the wrapped
@@ -269,6 +305,10 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -298,34 +338,49 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         """
         return AwaitableResultTupleWrapper.construct_successes_from_awaitable(
             self.core
-        ).map_successes_to_awaitable_result_iterable(f)
+        ).map_successes_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_to_awaitable_result_iterable instead")
     def map_to_awaitable_result_tuple(
-        self, f: Callable[[_T_co], AwaitableResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableWrapper.map_to_awaitable_result_iterable][].
         """
-        return self.map_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.map_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_to_awaitable_iterable instead")
     def map_to_awaitable_tuple(
-        self, f: Callable[[_T_co], AwaitableTuple[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableTuple[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Deprecated alias for
         [trcks.oop.AwaitableWrapper.map_to_awaitable_iterable][].
         """
-        return self.map_to_awaitable_iterable(f)  # pragma: no cover
+        return self.map_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def map_to_iterable(
-        self, f: Callable[[_T_co], Iterable[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Iterable[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Apply a synchronous function returning an [collections.abc.Iterable][]
         to the wrapped [collections.abc.Awaitable][] object.
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -344,16 +399,25 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
             >>> asyncio.run(awaitable_tuple_wrapper.core_as_coroutine)
             (3, -3)
         """
-        return AwaitableTupleWrapper(a.map_(tuple)(a.map_(f)(self.core)))
+        return AwaitableTupleWrapper(
+            a.map_(tuple)(a.map_(f, *args, **kwargs)(self.core))
+        )
 
     def map_to_result(
-        self, f: Callable[[_T_co], Result[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Result[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F, _S]:
         """Apply a synchronous function with return type [trcks.Result][]
         to the wrapped [collections.abc.Awaitable][] object.
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance with
@@ -378,16 +442,23 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         """
         return AwaitableResultWrapper.construct_success_from_awaitable(
             self.core
-        ).map_success_to_result(f)
+        ).map_success_to_result(f, *args, **kwargs)
 
     def map_to_result_iterable(
-        self, f: Callable[[_T_co], ResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], ResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S]:
         """Apply a synchronous function with return type [trcks.ResultIterable][]
         to the wrapped [collections.abc.Awaitable][] object.
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -412,32 +483,47 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         """
         return AwaitableResultTupleWrapper.construct_successes_from_awaitable(
             self.core
-        ).map_successes_to_result_iterable(f)
+        ).map_successes_to_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_to_result_iterable instead")
     def map_to_result_tuple(
-        self, f: Callable[[_T_co], ResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], ResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S]:
         """Deprecated alias for
         [trcks.oop.AwaitableWrapper.map_to_result_iterable][].
         """
-        return self.map_to_result_iterable(f)  # pragma: no cover
+        return self.map_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
     @deprecated("Use map_to_iterable instead")
     def map_to_tuple(
-        self, f: Callable[[_T_co], tuple[_T, ...]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], tuple[_T, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Deprecated alias for
         [trcks.oop.AwaitableWrapper.map_to_iterable][].
         """
-        return self.map_to_iterable(f)  # pragma: no cover
+        return self.map_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
-    def tap(self, f: Callable[[_T_co], object]) -> AwaitableWrapper[_T_co]:
+    def tap(
+        self,
+        f: Callable[Concatenate[_T_co, _P], object],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> AwaitableWrapper[_T_co]:
         """Apply a synchronous side effect
         to the wrapped [collections.abc.Awaitable][] object.
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableWrapper][] instance with
@@ -454,16 +540,23 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
             >>> value
             'Hello, world!'
         """
-        return AwaitableWrapper(a.tap(f)(self.core))
+        return AwaitableWrapper(a.tap(f, *args, **kwargs)(self.core))
 
     def tap_to_awaitable(
-        self, f: Callable[[_T_co], Awaitable[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Awaitable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableWrapper[_T_co]:
         """Apply an asynchronous side effect
         to the wrapped [collections.abc.Awaitable][] object.
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableWrapper][] instance with the original wrapped object.
@@ -483,10 +576,13 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
             >>> value
             'Hello, world!'
         """
-        return AwaitableWrapper(a.tap_to_awaitable(f)(self.core))
+        return AwaitableWrapper(a.tap_to_awaitable(f, *args, **kwargs)(self.core))
 
     def tap_to_awaitable_iterable(
-        self, f: Callable[[_T_co], AwaitableIterable[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableIterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Apply an asynchronous side effect returning a [trcks.AwaitableIterable][]
         to the wrapped [collections.abc.Awaitable][] object.
@@ -494,6 +590,10 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         Args:
             f: The asynchronous side effect to be applied,
                 returning a [trcks.AwaitableIterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -521,16 +621,23 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         """
         return AwaitableTupleWrapper.construct_from_awaitable(
             self.core
-        ).tap_to_awaitable_iterable(f)
+        ).tap_to_awaitable_iterable(f, *args, **kwargs)
 
     def tap_to_awaitable_result(
-        self, f: Callable[[_T_co], AwaitableResult[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResult[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F, _T_co]:
         """Apply an asynchronous side effect with return type [trcks.Result][]
         to the wrapped object.
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance with
@@ -571,10 +678,13 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         """
         return AwaitableResultWrapper.construct_success_from_awaitable(
             self.core
-        ).tap_success_to_awaitable_result(f)
+        ).tap_success_to_awaitable_result(f, *args, **kwargs)
 
     def tap_to_awaitable_result_iterable(
-        self, f: Callable[[_T_co], AwaitableResultIterable[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResultIterable[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _T_co]:
         """Apply an asynchronous side effect with return type
         [trcks.AwaitableResultIterable][] to the wrapped
@@ -582,6 +692,10 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -615,28 +729,39 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         """
         return AwaitableResultTupleWrapper.construct_successes_from_awaitable(
             self.core
-        ).tap_successes_to_awaitable_result_iterable(f)
+        ).tap_successes_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_to_awaitable_result_iterable instead")
     def tap_to_awaitable_result_tuple(
-        self, f: Callable[[_T_co], AwaitableResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _T_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableWrapper.tap_to_awaitable_result_iterable][].
         """
-        return self.tap_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.tap_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_to_awaitable_iterable instead")
     def tap_to_awaitable_tuple(
-        self, f: Callable[[_T_co], AwaitableTuple[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableTuple[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableWrapper.tap_to_awaitable_iterable][].
         """
-        return self.tap_to_awaitable_iterable(f)  # pragma: no cover
+        return self.tap_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def tap_to_iterable(
-        self, f: Callable[[_T_co], Iterable[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Iterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Apply a synchronous side effect returning an [collections.abc.Iterable][]
         to the wrapped [collections.abc.Awaitable][] object.
@@ -644,6 +769,10 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         Args:
             f: The synchronous side effect to be applied,
                 returning an [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -670,16 +799,23 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         """
         return AwaitableTupleWrapper.construct_from_awaitable(
             self.core
-        ).tap_to_iterable(f)
+        ).tap_to_iterable(f, *args, **kwargs)
 
     def tap_to_result(
-        self, f: Callable[[_T_co], Result[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Result[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F, _T_co]:
         """Apply a synchronous side effect with return type [trcks.Result][]
         to the wrapped object.
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance with
@@ -715,16 +851,23 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         """
         return AwaitableResultWrapper.construct_success_from_awaitable(
             self.core
-        ).tap_success_to_result(f)
+        ).tap_success_to_result(f, *args, **kwargs)
 
     def tap_to_result_iterable(
-        self, f: Callable[[_T_co], ResultIterable[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], ResultIterable[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _T_co]:
         """Apply a synchronous side effect with return type [trcks.ResultIterable][]
         to the wrapped [collections.abc.Awaitable][] object.
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -755,22 +898,28 @@ class AwaitableWrapper(BaseAwaitableWrapper[_T_co]):
         """
         return AwaitableResultTupleWrapper.construct_successes_from_awaitable(
             self.core
-        ).tap_successes_to_result_iterable(f)
+        ).tap_successes_to_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_to_result_iterable instead")
     def tap_to_result_tuple(
-        self, f: Callable[[_T_co], ResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], ResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _T_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableWrapper.tap_to_result_iterable][].
         """
-        return self.tap_to_result_iterable(f)  # pragma: no cover
+        return self.tap_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
     @deprecated("Use tap_to_iterable instead")
     def tap_to_tuple(
-        self, f: Callable[[_T_co], tuple[object, ...]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], tuple[object, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Deprecated alias for
         [trcks.oop.AwaitableWrapper.tap_to_iterable][].
         """
-        return self.tap_to_iterable(f)  # pragma: no cover
+        return self.tap_to_iterable(f, *args, **kwargs)  # pragma: no cover

--- a/src/trcks/oop/_result_tuple_wrapper.py
+++ b/src/trcks/oop/_result_tuple_wrapper.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, Concatenate, ParamSpec, final
 
 from trcks import ResultTuple
 from trcks._typing import Never, TypeVar, deprecated
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 __docformat__ = "google"
 
 _F = TypeVar("_F")
+_P = ParamSpec("_P")
 _S = TypeVar("_S")
 
 _F_default = TypeVar("_F_default", default=Never)
@@ -186,7 +187,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         return cls.construct_successes_from_iterable(tpl)  # pragma: no cover
 
     def map_failure(
-        self, f: Callable[[_F_default_co], _F]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], _F],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _S_default_co]:
         """Apply a synchronous function to the wrapped [trcks.Failure][] object.
 
@@ -194,6 +198,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -217,10 +225,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
             ... ).map_failure(_add_prefix)
             ResultTupleWrapper(core=('success', (1, 2)))
         """
-        return ResultTupleWrapper(rt.map_failure(f)(self.core))
+        return ResultTupleWrapper(rt.map_failure(f, *args, **kwargs)(self.core))
 
     def map_failure_to_awaitable(
-        self, f: Callable[[_F_default_co], Awaitable[_F]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Awaitable[_F]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co]:
         """Apply an asynchronous function to the wrapped [trcks.Failure][] object.
 
@@ -228,6 +239,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -261,10 +276,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).map_failure_to_awaitable(f)
+        ).map_failure_to_awaitable(f, *args, **kwargs)
 
     def map_failure_to_awaitable_iterable(
-        self, f: Callable[[_F_default_co], AwaitableIterable[_S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableIterable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
         """Apply an asynchronous function returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Failure][] object.
@@ -274,6 +292,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         Args:
             f: The asynchronous function returning an
                 [collections.abc.Iterable][] to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -312,10 +334,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).map_failure_to_awaitable_iterable(f)
+        ).map_failure_to_awaitable_iterable(f, *args, **kwargs)
 
     def map_failure_to_awaitable_result(
-        self, f: Callable[[_F_default_co], AwaitableResult[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResult[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Apply an asynchronous function with return type [trcks.AwaitableResult][]
         to the wrapped [trcks.Failure][] object.
@@ -324,6 +349,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -368,10 +397,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).map_failure_to_awaitable_result(f)
+        ).map_failure_to_awaitable_result(f, *args, **kwargs)
 
     def map_failure_to_awaitable_result_iterable(
-        self, f: Callable[[_F_default_co], AwaitableResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Apply an asynchronous function with return type
         [trcks.AwaitableResultIterable][] to the wrapped [trcks.Failure][] object.
@@ -380,6 +412,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -418,28 +454,41 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).map_failure_to_awaitable_result_iterable(f)
+        ).map_failure_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_failure_to_awaitable_result_iterable instead")
     def map_failure_to_awaitable_result_tuple(
-        self, f: Callable[[_F_default_co], AwaitableResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.map_failure_to_awaitable_result_iterable][].
         """
-        return self.map_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.map_failure_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_failure_to_awaitable_iterable instead")
     def map_failure_to_awaitable_tuple(
-        self, f: Callable[[_F_default_co], AwaitableTuple[_S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableTuple[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.map_failure_to_awaitable_iterable][].
         """
-        return self.map_failure_to_awaitable_iterable(f)  # pragma: no cover
+        return self.map_failure_to_awaitable_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def map_failure_to_iterable(
-        self, f: Callable[[_F_default_co], Iterable[_S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Iterable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[Never, _S_default_co | _S]:
         """Apply a synchronous function returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Failure][] object.
@@ -448,6 +497,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -482,11 +535,14 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         mapped_f: Callable[
             [ResultTuple[_F_default_co, _S_default_co]],
             ResultTuple[Never, _S_default_co | _S],
-        ] = rt.map_failure_to_iterable(f)
+        ] = rt.map_failure_to_iterable(f, *args, **kwargs)
         return ResultTupleWrapper(mapped_f(self.core))
 
     def map_failure_to_result(
-        self, f: Callable[[_F_default_co], Result[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Result[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _S_default_co | _S]:
         """Apply a synchronous function with return type [trcks.Result][]
         to the wrapped [trcks.Failure][] object.
@@ -495,6 +551,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -529,11 +589,14 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         mapped_f: Callable[
             [ResultTuple[_F_default_co, _S_default_co]],
             ResultTuple[_F, _S_default_co | _S],
-        ] = rt.map_failure_to_result(f)
+        ] = rt.map_failure_to_result(f, *args, **kwargs)
         return ResultTupleWrapper(mapped_f(self.core))
 
     def map_failure_to_result_iterable(
-        self, f: Callable[[_F_default_co], ResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _S_default_co | _S]:
         """Apply a synchronous function with return type [trcks.ResultIterable][]
         to the wrapped [trcks.Failure][] object.
@@ -542,6 +605,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -576,29 +643,40 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         mapped_f: Callable[
             [ResultTuple[_F_default_co, _S_default_co]],
             ResultTuple[_F, _S_default_co | _S],
-        ] = rt.map_failure_to_result_iterable(f)
+        ] = rt.map_failure_to_result_iterable(f, *args, **kwargs)
         return ResultTupleWrapper(mapped_f(self.core))
 
     @deprecated("Use map_failure_to_result_iterable instead")
     def map_failure_to_result_tuple(
-        self, f: Callable[[_F_default_co], ResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.map_failure_to_result_iterable][].
         """
-        return self.map_failure_to_result_iterable(f)  # pragma: no cover
+        return self.map_failure_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_failure_to_iterable instead")
     def map_failure_to_tuple(
-        self, f: Callable[[_F_default_co], tuple[_S, ...]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], tuple[_S, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[Never, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.map_failure_to_iterable][].
         """
-        return self.map_failure_to_iterable(f)  # pragma: no cover
+        return self.map_failure_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def map_successes(
-        self, f: Callable[[_S_default_co], _S]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], _S],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S]:
         """Apply a synchronous function to each element in the wrapped
         [trcks.SuccessTuple][].
@@ -607,6 +685,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous function to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -630,10 +712,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
             ... )
             ResultTupleWrapper(core=('failure', 'not found'))
         """
-        return ResultTupleWrapper(rt.map_successes(f)(self.core))
+        return ResultTupleWrapper(rt.map_successes(f, *args, **kwargs)(self.core))
 
     def map_successes_to_awaitable(
-        self, f: Callable[[_S_default_co], Awaitable[_S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Awaitable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
         """Apply an asynchronous function to each element in the wrapped
         [trcks.SuccessTuple][].
@@ -642,6 +727,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The asynchronous function to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -675,10 +764,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).map_successes_to_awaitable(f)
+        ).map_successes_to_awaitable(f, *args, **kwargs)
 
     def map_successes_to_awaitable_iterable(
-        self, f: Callable[[_S_default_co], AwaitableIterable[_S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableIterable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
         """Apply an asynchronous function returning an [collections.abc.Iterable][]
         to each element in the wrapped [trcks.SuccessTuple][] and flatten.
@@ -688,6 +780,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         Args:
             f: The asynchronous function returning an
                 [collections.abc.Iterable][] to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -721,10 +817,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).map_successes_to_awaitable_iterable(f)
+        ).map_successes_to_awaitable_iterable(f, *args, **kwargs)
 
     def map_successes_to_awaitable_result(
-        self, f: Callable[[_S_default_co], AwaitableResult[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResult[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Apply an asynchronous function with return type [trcks.Result][]
         to each element in the wrapped [trcks.SuccessTuple][].
@@ -733,6 +832,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The asynchronous function to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -770,10 +873,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).map_successes_to_awaitable_result(f)
+        ).map_successes_to_awaitable_result(f, *args, **kwargs)
 
     def map_successes_to_awaitable_result_iterable(
-        self, f: Callable[[_S_default_co], AwaitableResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Apply an asynchronous function with return type
         [trcks.AwaitableResultIterable][] to each element in the wrapped
@@ -783,6 +889,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The asynchronous function to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -822,28 +932,41 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).map_successes_to_awaitable_result_iterable(f)
+        ).map_successes_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_successes_to_awaitable_result_iterable instead")
     def map_successes_to_awaitable_result_tuple(
-        self, f: Callable[[_S_default_co], AwaitableResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.map_successes_to_awaitable_result_iterable][].
         """
-        return self.map_successes_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.map_successes_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_successes_to_awaitable_iterable instead")
     def map_successes_to_awaitable_tuple(
-        self, f: Callable[[_S_default_co], AwaitableTuple[_S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableTuple[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.map_successes_to_awaitable_iterable][].
         """
-        return self.map_successes_to_awaitable_iterable(f)  # pragma: no cover
+        return self.map_successes_to_awaitable_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def map_successes_to_iterable(
-        self, f: Callable[[_S_default_co], Iterable[_S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Iterable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S]:
         """Apply a synchronous function returning an [collections.abc.Iterable][]
         to each element in the wrapped [trcks.SuccessTuple][] and flatten.
@@ -852,6 +975,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous function to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -875,10 +1002,15 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
             ... ).map_successes_to_iterable(_duplicate_integer)
             ResultTupleWrapper(core=('failure', 'not found'))
         """
-        return ResultTupleWrapper(rt.map_successes_to_iterable(f)(self.core))
+        return ResultTupleWrapper(
+            rt.map_successes_to_iterable(f, *args, **kwargs)(self.core)
+        )
 
     def map_successes_to_result(
-        self, f: Callable[[_S_default_co], Result[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Result[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co | _F, _S]:
         """Apply a synchronous function with return type [trcks.Result][]
         to each element in the wrapped [trcks.SuccessTuple][].
@@ -887,6 +1019,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous function to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -922,11 +1058,14 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         mapped_f: Callable[
             [ResultTuple[_F_default_co, _S_default_co]],
             ResultTuple[_F_default_co | _F, _S],
-        ] = rt.map_successes_to_result(f)
+        ] = rt.map_successes_to_result(f, *args, **kwargs)
         return ResultTupleWrapper(mapped_f(self.core))
 
     def map_successes_to_result_iterable(
-        self, f: Callable[[_S_default_co], ResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co | _F, _S]:
         """Apply a synchronous function with return type [trcks.ResultIterable][]
         to each element in the wrapped [trcks.SuccessTuple][] and flatten.
@@ -935,6 +1074,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous function to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -970,29 +1113,40 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         mapped_f: Callable[
             [ResultTuple[_F_default_co, _S_default_co]],
             ResultTuple[_F_default_co | _F, _S],
-        ] = rt.map_successes_to_result_iterable(f)
+        ] = rt.map_successes_to_result_iterable(f, *args, **kwargs)
         return ResultTupleWrapper(mapped_f(self.core))
 
     @deprecated("Use map_successes_to_result_iterable instead")
     def map_successes_to_result_tuple(
-        self, f: Callable[[_S_default_co], ResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co | _F, _S]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.map_successes_to_result_iterable][].
         """
-        return self.map_successes_to_result_iterable(f)  # pragma: no cover
+        return self.map_successes_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_successes_to_iterable instead")
     def map_successes_to_tuple(
-        self, f: Callable[[_S_default_co], tuple[_S, ...]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], tuple[_S, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.map_successes_to_iterable][].
         """
-        return self.map_successes_to_iterable(f)  # pragma: no cover
+        return self.map_successes_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def tap_failure(
-        self, f: Callable[[_F_default_co], object]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], object],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply a synchronous side effect to the wrapped [trcks.Failure][] object.
 
@@ -1000,6 +1154,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance
@@ -1025,10 +1183,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
             >>> result_tuple_wrapper_2
             ResultTupleWrapper(core=('success', (1,)))
         """
-        return ResultTupleWrapper(rt.tap_failure(f)(self.core))
+        return ResultTupleWrapper(rt.tap_failure(f, *args, **kwargs)(self.core))
 
     def tap_failure_to_awaitable(
-        self, f: Callable[[_F_default_co], Awaitable[object]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Awaitable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply an asynchronous side effect to the wrapped
         [trcks.Failure][] object.
@@ -1038,6 +1199,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1070,10 +1235,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).tap_failure_to_awaitable(f)
+        ).tap_failure_to_awaitable(f, *args, **kwargs)
 
     def tap_failure_to_awaitable_iterable(
-        self, f: Callable[[_F_default_co], AwaitableIterable[object]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableIterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Apply an asynchronous side effect returning an
         [collections.abc.Iterable][] to the wrapped [trcks.Failure][] object.
@@ -1087,6 +1255,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         Args:
             f: The asynchronous side effect returning an
                 [collections.abc.Iterable][] to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1131,10 +1303,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).tap_failure_to_awaitable_iterable(f)
+        ).tap_failure_to_awaitable_iterable(f, *args, **kwargs)
 
     def tap_failure_to_awaitable_result(
-        self, f: Callable[[_F_default_co], AwaitableResult[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResult[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Apply an asynchronous side effect with return type [trcks.Result][]
         to the wrapped [trcks.Failure][] object.
@@ -1144,6 +1319,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1183,10 +1362,15 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).tap_failure_to_awaitable_result(f)
+        ).tap_failure_to_awaitable_result(f, *args, **kwargs)
 
     def tap_failure_to_awaitable_result_iterable(
-        self, f: Callable[[_F_default_co], AwaitableResultIterable[object, _S]]
+        self,
+        f: Callable[
+            Concatenate[_F_default_co, _P], AwaitableResultIterable[object, _S]
+        ],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Apply an asynchronous side effect with return type
         [trcks.AwaitableResultIterable][] to the wrapped [trcks.Failure][] object.
@@ -1196,6 +1380,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1238,28 +1426,41 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).tap_failure_to_awaitable_result_iterable(f)
+        ).tap_failure_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_failure_to_awaitable_result_iterable instead")
     def tap_failure_to_awaitable_result_tuple(
-        self, f: Callable[[_F_default_co], AwaitableResultTuple[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResultTuple[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.tap_failure_to_awaitable_result_iterable][].
         """
-        return self.tap_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_failure_to_awaitable_iterable instead")
     def tap_failure_to_awaitable_tuple(
-        self, f: Callable[[_F_default_co], AwaitableTuple[object]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableTuple[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.tap_failure_to_awaitable_iterable][].
         """
-        return self.tap_failure_to_awaitable_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_awaitable_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def tap_failure_to_iterable(
-        self, f: Callable[[_F_default_co], Iterable[object]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Iterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Apply a synchronous side effect returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Failure][] object.
@@ -1272,6 +1473,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -1305,11 +1510,14 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         tapped_f: Callable[
             [ResultTuple[_F_default_co, _S_default_co]],
             ResultTuple[Never, _F_default_co | _S_default_co],
-        ] = rt.tap_failure_to_iterable(f)
+        ] = rt.tap_failure_to_iterable(f, *args, **kwargs)
         return ResultTupleWrapper(tapped_f(self.core))
 
     def tap_failure_to_result(
-        self, f: Callable[[_F_default_co], Result[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Result[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Apply a synchronous side effect with return type [trcks.Result][]
         to the wrapped [trcks.Failure][] object.
@@ -1318,6 +1526,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -1355,11 +1567,14 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         tapped_f: Callable[
             [ResultTuple[_F_default_co, _S_default_co]],
             ResultTuple[_F_default_co, _S_default_co | _S],
-        ] = rt.tap_failure_to_result(f)
+        ] = rt.tap_failure_to_result(f, *args, **kwargs)
         return ResultTupleWrapper(tapped_f(self.core))
 
     def tap_failure_to_result_iterable(
-        self, f: Callable[[_F_default_co], ResultIterable[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultIterable[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Apply a synchronous side effect with return type [trcks.ResultIterable][]
         to the wrapped [trcks.Failure][] object.
@@ -1368,6 +1583,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -1405,29 +1624,40 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         tapped_f: Callable[
             [ResultTuple[_F_default_co, _S_default_co]],
             ResultTuple[_F_default_co, _S_default_co | _S],
-        ] = rt.tap_failure_to_result_iterable(f)
+        ] = rt.tap_failure_to_result_iterable(f, *args, **kwargs)
         return ResultTupleWrapper(tapped_f(self.core))
 
     @deprecated("Use tap_failure_to_result_iterable instead")
     def tap_failure_to_result_tuple(
-        self, f: Callable[[_F_default_co], ResultTuple[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultTuple[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.tap_failure_to_result_iterable][].
         """
-        return self.tap_failure_to_result_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_failure_to_iterable instead")
     def tap_failure_to_tuple(
-        self, f: Callable[[_F_default_co], tuple[object, ...]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], tuple[object, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.tap_failure_to_iterable][].
         """
-        return self.tap_failure_to_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def tap_successes(
-        self, f: Callable[[_S_default_co], object]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], object],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply a synchronous side effect to each element in the wrapped
         [trcks.SuccessTuple][].
@@ -1436,6 +1666,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous side effect to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance
@@ -1461,10 +1695,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
             >>> result_tuple_wrapper_2
             ResultTupleWrapper(core=('failure', 'oops'))
         """
-        return ResultTupleWrapper(rt.tap_successes(f)(self.core))
+        return ResultTupleWrapper(rt.tap_successes(f, *args, **kwargs)(self.core))
 
     def tap_successes_to_awaitable(
-        self, f: Callable[[_S_default_co], Awaitable[object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Awaitable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply an asynchronous side effect to each element in the wrapped
         [trcks.SuccessTuple][].
@@ -1473,6 +1710,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The asynchronous side effect to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1506,10 +1747,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).tap_successes_to_awaitable(f)
+        ).tap_successes_to_awaitable(f, *args, **kwargs)
 
     def tap_successes_to_awaitable_iterable(
-        self, f: Callable[[_S_default_co], AwaitableIterable[object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableIterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply an asynchronous side effect returning an
         [collections.abc.Iterable][] to each element in the wrapped
@@ -1523,6 +1767,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         Args:
             f: The asynchronous side effect returning an
                 [collections.abc.Iterable][] to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1552,10 +1800,13 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).tap_successes_to_awaitable_iterable(f)
+        ).tap_successes_to_awaitable_iterable(f, *args, **kwargs)
 
     def tap_successes_to_awaitable_result(
-        self, f: Callable[[_S_default_co], AwaitableResult[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResult[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Apply an asynchronous side effect with return type [trcks.Result][]
         to each element in the wrapped [trcks.SuccessTuple][].
@@ -1564,6 +1815,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The asynchronous side effect to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1602,10 +1857,15 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).tap_successes_to_awaitable_result(f)
+        ).tap_successes_to_awaitable_result(f, *args, **kwargs)
 
     def tap_successes_to_awaitable_result_iterable(
-        self, f: Callable[[_S_default_co], AwaitableResultIterable[_F, object]]
+        self,
+        f: Callable[
+            Concatenate[_S_default_co, _P], AwaitableResultIterable[_F, object]
+        ],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Apply an asynchronous side effect with return type
         [trcks.AwaitableResultIterable][] to each element in the wrapped
@@ -1615,6 +1875,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The asynchronous side effect to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1657,28 +1921,41 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
         """
         return AwaitableResultTupleWrapper.construct_from_result_iterable(
             self.core
-        ).tap_successes_to_awaitable_result_iterable(f)
+        ).tap_successes_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_successes_to_awaitable_result_iterable instead")
     def tap_successes_to_awaitable_result_tuple(
-        self, f: Callable[[_S_default_co], AwaitableResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.tap_successes_to_awaitable_result_iterable][].
         """
-        return self.tap_successes_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.tap_successes_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_successes_to_awaitable_iterable instead")
     def tap_successes_to_awaitable_tuple(
-        self, f: Callable[[_S_default_co], AwaitableTuple[object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableTuple[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.tap_successes_to_awaitable_iterable][].
         """
-        return self.tap_successes_to_awaitable_iterable(f)  # pragma: no cover
+        return self.tap_successes_to_awaitable_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def tap_successes_to_iterable(
-        self, f: Callable[[_S_default_co], Iterable[object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Iterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply a synchronous side effect returning an [collections.abc.Iterable][]
         to each element in the wrapped [trcks.SuccessTuple][].
@@ -1690,6 +1967,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous side effect to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -1711,10 +1992,15 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
             Received: 7
             ResultTupleWrapper(core=('success', (7, 7)))
         """
-        return ResultTupleWrapper(rt.tap_successes_to_iterable(f)(self.core))
+        return ResultTupleWrapper(
+            rt.tap_successes_to_iterable(f, *args, **kwargs)(self.core)
+        )
 
     def tap_successes_to_result(
-        self, f: Callable[[_S_default_co], Result[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Result[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Apply a synchronous side effect with return type [trcks.Result][]
         to each element in the wrapped [trcks.SuccessTuple][].
@@ -1723,6 +2009,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous side effect to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -1757,10 +2047,15 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
             ... ).tap_successes_to_result(_validate_positive)
             ResultTupleWrapper(core=('failure', 'oops'))
         """
-        return ResultTupleWrapper(rt.tap_successes_to_result(f)(self.core))
+        return ResultTupleWrapper(
+            rt.tap_successes_to_result(f, *args, **kwargs)(self.core)
+        )
 
     def tap_successes_to_result_iterable(
-        self, f: Callable[[_S_default_co], ResultIterable[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultIterable[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Apply a synchronous side effect with return type [trcks.ResultIterable][]
         to each element in the wrapped [trcks.SuccessTuple][].
@@ -1769,6 +2064,10 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
 
         Args:
             f: The synchronous side effect to be applied to each success element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultTupleWrapper][] instance with
@@ -1798,22 +2097,32 @@ class ResultTupleWrapper(BaseWrapper[ResultTuple[_F_default_co, _S_default_co]])
             ... ).tap_successes_to_result_iterable(_validate_positive_twice)
             ResultTupleWrapper(core=('failure', 'not positive'))
         """
-        return ResultTupleWrapper(rt.tap_successes_to_result_iterable(f)(self.core))
+        return ResultTupleWrapper(
+            rt.tap_successes_to_result_iterable(f, *args, **kwargs)(self.core)
+        )
 
     @deprecated("Use tap_successes_to_result_iterable instead")
     def tap_successes_to_result_tuple(
-        self, f: Callable[[_S_default_co], ResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.tap_successes_to_result_iterable][].
         """
-        return self.tap_successes_to_result_iterable(f)  # pragma: no cover
+        return self.tap_successes_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_successes_to_iterable instead")
     def tap_successes_to_tuple(
-        self, f: Callable[[_S_default_co], tuple[object, ...]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], tuple[object, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S_default_co]:
         """Deprecated alias for
         [trcks.oop.ResultTupleWrapper.tap_successes_to_iterable][].
         """
-        return self.tap_successes_to_iterable(f)  # pragma: no cover
+        return self.tap_successes_to_iterable(f, *args, **kwargs)  # pragma: no cover

--- a/src/trcks/oop/_result_wrapper.py
+++ b/src/trcks/oop/_result_wrapper.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, Concatenate, ParamSpec, final
 
 from trcks import Result
 from trcks._typing import Never, TypeVar, deprecated
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 __docformat__ = "google"
 
 _F = TypeVar("_F")
+_P = ParamSpec("_P")
 _S = TypeVar("_S")
 
 
@@ -119,7 +120,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         return ResultWrapper(r.construct_success(value))
 
     def map_failure(
-        self, f: Callable[[_F_default_co], _F]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], _F],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultWrapper[_F, _S_default_co]:
         """Apply a synchronous function to the wrapped [trcks.Failure][] object.
 
@@ -127,6 +131,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultWrapper][] instance with
@@ -146,10 +154,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
             ... )
             ResultWrapper(core=('success', 25.0))
         """
-        return ResultWrapper(r.map_failure(f)(self.core))
+        return ResultWrapper(r.map_failure(f, *args, **kwargs)(self.core))
 
     def map_failure_to_awaitable(
-        self, f: Callable[[_F_default_co], Awaitable[_F]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Awaitable[_F]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F, _S_default_co]:
         """Apply an asynchronous function to the wrapped [trcks.Failure][] object.
 
@@ -157,6 +168,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance with
@@ -194,10 +209,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return AwaitableResultWrapper.construct_from_result(
             self.core
-        ).map_failure_to_awaitable(f)
+        ).map_failure_to_awaitable(f, *args, **kwargs)
 
     def map_failure_to_awaitable_result(
-        self, f: Callable[[_F_default_co], AwaitableResult[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResult[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F, _S_default_co | _S]:
         """Apply an asynchronous function with return type [trcks.Result][]
         to the wrapped [trcks.Failure][] object.
@@ -206,6 +224,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance with
@@ -256,10 +278,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return AwaitableResultWrapper.construct_from_result(
             self.core
-        ).map_failure_to_awaitable_result(f)
+        ).map_failure_to_awaitable_result(f, *args, **kwargs)
 
     def map_failure_to_awaitable_result_iterable(
-        self, f: Callable[[_F_default_co], AwaitableResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Apply an asynchronous function with return type
         [trcks.AwaitableResultIterable][] to the wrapped [trcks.Failure][] object.
@@ -268,6 +293,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -310,19 +339,27 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return AwaitableResultTupleWrapper.construct_from_result(
             self.core
-        ).map_failure_to_awaitable_result_iterable(f)
+        ).map_failure_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_failure_to_awaitable_result_iterable instead")
     def map_failure_to_awaitable_result_tuple(
-        self, f: Callable[[_F_default_co], AwaitableResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.ResultWrapper.map_failure_to_awaitable_result_iterable][].
         """
-        return self.map_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.map_failure_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def map_failure_to_iterable(
-        self, f: Callable[[_F_default_co], Iterable[_S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Iterable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[Never, _S_default_co | _S]:
         """Apply a synchronous function returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Failure][] object.
@@ -333,6 +370,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         Args:
             f: The synchronous function to be applied,
                 returning an [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -367,10 +408,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return ResultTupleWrapper.construct_from_result(
             self.core
-        ).map_failure_to_iterable(f)
+        ).map_failure_to_iterable(f, *args, **kwargs)
 
     def map_failure_to_result(
-        self, f: Callable[[_F_default_co], Result[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Result[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultWrapper[_F, _S_default_co | _S]:
         """Apply a synchronous function with return type [trcks.Result][]
         to the wrapped [trcks.Failure][] object.
@@ -379,6 +423,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultWrapper][] instance with
@@ -416,10 +464,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
             ... )
             ResultWrapper(core=('success', 25.0))
         """
-        return ResultWrapper(r.map_failure_to_result(f)(self.core))
+        return ResultWrapper(r.map_failure_to_result(f, *args, **kwargs)(self.core))
 
     def map_failure_to_result_iterable(
-        self, f: Callable[[_F_default_co], ResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _S_default_co | _S]:
         """Apply a synchronous function with return type [trcks.ResultIterable][]
         to the wrapped [trcks.Failure][] object.
@@ -428,6 +479,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -462,26 +517,37 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return ResultTupleWrapper.construct_from_result(
             self.core
-        ).map_failure_to_result_iterable(f)
+        ).map_failure_to_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_failure_to_result_iterable instead")
     def map_failure_to_result_tuple(
-        self, f: Callable[[_F_default_co], ResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.ResultWrapper.map_failure_to_result_iterable][].
         """
-        return self.map_failure_to_result_iterable(f)  # pragma: no cover
+        return self.map_failure_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_failure_to_iterable instead")
     def map_failure_to_tuple(
-        self, f: Callable[[_F_default_co], tuple[_S, ...]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], tuple[_S, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[Never, _S_default_co | _S]:
         """Deprecated alias for [trcks.oop.ResultWrapper.map_failure_to_iterable][]."""
-        return self.map_failure_to_iterable(f)  # pragma: no cover
+        return self.map_failure_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def map_success(
-        self, f: Callable[[_S_default_co], _S]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], _S],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultWrapper[_F_default_co, _S]:
         """Apply a synchronous function to the wrapped [trcks.Success][] object.
 
@@ -489,6 +555,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultWrapper][] instance with
@@ -504,10 +574,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
             >>> ResultWrapper.construct_success(42).map_success(lambda n: n+1)
             ResultWrapper(core=('success', 43))
         """
-        return ResultWrapper(r.map_success(f)(self.core))
+        return ResultWrapper(r.map_success(f, *args, **kwargs)(self.core))
 
     def map_success_to_awaitable(
-        self, f: Callable[[_S_default_co], Awaitable[_S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Awaitable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co, _S]:
         """Apply an asynchronous function to the wrapped [trcks.Success][] object.
 
@@ -515,6 +588,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance with
@@ -552,10 +629,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return AwaitableResultWrapper.construct_from_result(
             self.core
-        ).map_success_to_awaitable(f)
+        ).map_success_to_awaitable(f, *args, **kwargs)
 
     def map_success_to_awaitable_result(
-        self, f: Callable[[_S_default_co], AwaitableResult[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResult[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co | _F, _S]:
         """Apply an asynchronous function with return type [trcks.Result][]
         to the wrapped [trcks.Success][] object.
@@ -564,6 +644,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance with
@@ -615,10 +699,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return AwaitableResultWrapper.construct_from_result(
             self.core
-        ).map_success_to_awaitable_result(f)
+        ).map_success_to_awaitable_result(f, *args, **kwargs)
 
     def map_success_to_awaitable_result_iterable(
-        self, f: Callable[[_S_default_co], AwaitableResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Apply an asynchronous function with return type
         [trcks.AwaitableResultIterable][] to the wrapped [trcks.Success][] object.
@@ -627,6 +714,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -669,19 +760,27 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return AwaitableResultTupleWrapper.construct_from_result(
             self.core
-        ).map_successes_to_awaitable_result_iterable(f)
+        ).map_successes_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_success_to_awaitable_result_iterable instead")
     def map_success_to_awaitable_result_tuple(
-        self, f: Callable[[_S_default_co], AwaitableResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S]:
         """Deprecated alias for
         [trcks.oop.ResultWrapper.map_success_to_awaitable_result_iterable][].
         """
-        return self.map_success_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.map_success_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def map_success_to_iterable(
-        self, f: Callable[[_S_default_co], Iterable[_S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Iterable[_S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S]:
         """Apply a synchronous function returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Success][] object.
@@ -691,6 +790,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         Args:
             f: The synchronous function to be applied,
                 returning an [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -717,10 +820,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return ResultTupleWrapper.construct_from_result(
             self.core
-        ).map_successes_to_iterable(f)
+        ).map_successes_to_iterable(f, *args, **kwargs)
 
     def map_success_to_result(
-        self, f: Callable[[_S_default_co], Result[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Result[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultWrapper[_F_default_co | _F, _S]:
         """Apply a synchronous function with return type [trcks.Result][]
         to the wrapped [trcks.Success][] object.
@@ -729,6 +835,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultWrapper][] instance with
@@ -761,10 +871,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
             ... )
             ResultWrapper(core=('success', 5.0))
         """
-        return ResultWrapper(r.map_success_to_result(f)(self.core))
+        return ResultWrapper(r.map_success_to_result(f, *args, **kwargs)(self.core))
 
     def map_success_to_result_iterable(
-        self, f: Callable[[_S_default_co], ResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co | _F, _S]:
         """Apply a synchronous function with return type [trcks.ResultIterable][]
         to the wrapped [trcks.Success][] object.
@@ -773,6 +886,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -806,26 +923,37 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return ResultTupleWrapper.construct_from_result(
             self.core
-        ).map_successes_to_result_iterable(f)
+        ).map_successes_to_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_success_to_result_iterable instead")
     def map_success_to_result_tuple(
-        self, f: Callable[[_S_default_co], ResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co | _F, _S]:
         """Deprecated alias for
         [trcks.oop.ResultWrapper.map_success_to_result_iterable][].
         """
-        return self.map_success_to_result_iterable(f)  # pragma: no cover
+        return self.map_success_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_success_to_iterable instead")
     def map_success_to_tuple(
-        self, f: Callable[[_S_default_co], tuple[_S, ...]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], tuple[_S, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S]:
         """Deprecated alias for [trcks.oop.ResultWrapper.map_success_to_iterable][]."""
-        return self.map_success_to_iterable(f)  # pragma: no cover
+        return self.map_success_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def tap_failure(
-        self, f: Callable[[_F_default_co], object]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], object],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultWrapper[_F_default_co, _S_default_co]:
         """Apply a synchronous side effect to the wrapped [trcks.Failure][] object.
 
@@ -833,6 +961,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultWrapper][] instance
@@ -852,10 +984,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
             >>> result_wrapper_2
             ResultWrapper(core=('success', 42))
         """
-        return ResultWrapper(r.tap_failure(f)(self.core))
+        return ResultWrapper(r.tap_failure(f, *args, **kwargs)(self.core))
 
     def tap_failure_to_awaitable(
-        self, f: Callable[[_F_default_co], Awaitable[object]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Awaitable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co, _S_default_co]:
         """Apply an asynchronous side effect to the wrapped [trcks.Failure][] object.
 
@@ -863,6 +998,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance
@@ -896,10 +1035,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return AwaitableResultWrapper.construct_from_result(
             self.core
-        ).tap_failure_to_awaitable(f)
+        ).tap_failure_to_awaitable(f, *args, **kwargs)
 
     def tap_failure_to_awaitable_result(
-        self, f: Callable[[_F_default_co], AwaitableResult[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResult[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co, _S_default_co | _S]:
         """Apply an asynchronous side effect with return type [trcks.Result][]
         to the wrapped [trcks.Failure][] object.
@@ -908,6 +1050,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance with
@@ -957,10 +1103,15 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return AwaitableResultWrapper.construct_from_result(
             self.core
-        ).tap_failure_to_awaitable_result(f)
+        ).tap_failure_to_awaitable_result(f, *args, **kwargs)
 
     def tap_failure_to_awaitable_result_iterable(
-        self, f: Callable[[_F_default_co], AwaitableResultIterable[object, _S]]
+        self,
+        f: Callable[
+            Concatenate[_F_default_co, _P], AwaitableResultIterable[object, _S]
+        ],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Apply an asynchronous side effect with return type
         [trcks.AwaitableResultIterable][] to the wrapped [trcks.Failure][] object.
@@ -969,6 +1120,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1014,19 +1169,27 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return AwaitableResultTupleWrapper.construct_from_result(
             self.core
-        ).tap_failure_to_awaitable_result_iterable(f)
+        ).tap_failure_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_failure_to_awaitable_result_iterable instead")
     def tap_failure_to_awaitable_result_tuple(
-        self, f: Callable[[_F_default_co], AwaitableResultTuple[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], AwaitableResultTuple[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.ResultWrapper.tap_failure_to_awaitable_result_iterable][].
         """
-        return self.tap_failure_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def tap_failure_to_iterable(
-        self, f: Callable[[_F_default_co], Iterable[object]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Iterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Apply a synchronous side effect returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Failure][] object.
@@ -1040,6 +1203,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         Args:
             f: The synchronous side effect to be applied,
                 returning an [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -1072,10 +1239,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return ResultTupleWrapper.construct_from_result(
             self.core
-        ).tap_failure_to_iterable(f)
+        ).tap_failure_to_iterable(f, *args, **kwargs)
 
     def tap_failure_to_result(
-        self, f: Callable[[_F_default_co], Result[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], Result[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultWrapper[_F_default_co, _S_default_co | _S]:
         """Apply a synchronous side effect with return type [trcks.Result][]
         to the wrapped [trcks.Failure][] object.
@@ -1084,6 +1254,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultWrapper][] instance with
@@ -1118,10 +1292,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
             >>> result_wrapper_3
             ResultWrapper(core=('success', 42))
         """
-        return ResultWrapper(r.tap_failure_to_result(f)(self.core))
+        return ResultWrapper(r.tap_failure_to_result(f, *args, **kwargs)(self.core))
 
     def tap_failure_to_result_iterable(
-        self, f: Callable[[_F_default_co], ResultIterable[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultIterable[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Apply a synchronous side effect with return type [trcks.ResultIterable][]
         to the wrapped [trcks.Failure][] object.
@@ -1130,6 +1307,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -1166,26 +1347,37 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return ResultTupleWrapper.construct_from_result(
             self.core
-        ).tap_failure_to_result_iterable(f)
+        ).tap_failure_to_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_failure_to_result_iterable instead")
     def tap_failure_to_result_tuple(
-        self, f: Callable[[_F_default_co], ResultTuple[object, _S]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], ResultTuple[object, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S_default_co | _S]:
         """Deprecated alias for
         [trcks.oop.ResultWrapper.tap_failure_to_result_iterable][].
         """
-        return self.tap_failure_to_result_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_failure_to_iterable instead")
     def tap_failure_to_tuple(
-        self, f: Callable[[_F_default_co], tuple[object, ...]]
+        self,
+        f: Callable[Concatenate[_F_default_co, _P], tuple[object, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[Never, _F_default_co | _S_default_co]:
         """Deprecated alias for [trcks.oop.ResultWrapper.tap_failure_to_iterable][]."""
-        return self.tap_failure_to_iterable(f)  # pragma: no cover
+        return self.tap_failure_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def tap_success(
-        self, f: Callable[[_S_default_co], object]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], object],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultWrapper[_F_default_co, _S_default_co]:
         """Apply a synchronous side effect to the wrapped [trcks.Success][] object.
 
@@ -1193,6 +1385,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultWrapper][] instance
@@ -1212,10 +1408,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
             >>> result_wrapper_2
             ResultWrapper(core=('success', 42))
         """
-        return ResultWrapper(r.tap_success(f)(self.core))
+        return ResultWrapper(r.tap_success(f, *args, **kwargs)(self.core))
 
     def tap_success_to_awaitable(
-        self, f: Callable[[_S_default_co], Awaitable[object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Awaitable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co, _S_default_co]:
         """Apply an asynchronous side effect to the wrapped [trcks.Success][] object.
 
@@ -1223,6 +1422,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance
@@ -1256,10 +1459,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return AwaitableResultWrapper.construct_from_result(
             self.core
-        ).tap_success_to_awaitable(f)
+        ).tap_success_to_awaitable(f, *args, **kwargs)
 
     def tap_success_to_awaitable_result(
-        self, f: Callable[[_S_default_co], AwaitableResult[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResult[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F_default_co | _F, _S_default_co]:
         """Apply an asynchronous side effect with return type [trcks.Result][]
         to the wrapped [trcks.Success][] object.
@@ -1268,6 +1474,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance with
@@ -1333,10 +1543,15 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return AwaitableResultWrapper.construct_from_result(
             self.core
-        ).tap_success_to_awaitable_result(f)
+        ).tap_success_to_awaitable_result(f, *args, **kwargs)
 
     def tap_success_to_awaitable_result_iterable(
-        self, f: Callable[[_S_default_co], AwaitableResultIterable[_F, object]]
+        self,
+        f: Callable[
+            Concatenate[_S_default_co, _P], AwaitableResultIterable[_F, object]
+        ],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Apply an asynchronous side effect with return type
         [trcks.AwaitableResultIterable][] to the wrapped [trcks.Success][] object.
@@ -1345,6 +1560,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -1391,19 +1610,27 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return AwaitableResultTupleWrapper.construct_from_result(
             self.core
-        ).tap_successes_to_awaitable_result_iterable(f)
+        ).tap_successes_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_success_to_awaitable_result_iterable instead")
     def tap_success_to_awaitable_result_tuple(
-        self, f: Callable[[_S_default_co], AwaitableResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], AwaitableResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Deprecated alias for
         [trcks.oop.ResultWrapper.tap_success_to_awaitable_result_iterable][].
         """
-        return self.tap_success_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.tap_success_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     def tap_success_to_iterable(
-        self, f: Callable[[_S_default_co], Iterable[object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Iterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S_default_co]:
         """Apply a synchronous side effect returning an [collections.abc.Iterable][]
         to the wrapped [trcks.Success][] object.
@@ -1416,6 +1643,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         Args:
             f: The synchronous side effect to be applied,
                 returning an [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -1446,10 +1677,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return ResultTupleWrapper.construct_from_result(
             self.core
-        ).tap_successes_to_iterable(f)
+        ).tap_successes_to_iterable(f, *args, **kwargs)
 
     def tap_success_to_result(
-        self, f: Callable[[_S_default_co], Result[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], Result[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultWrapper[_F_default_co | _F, _S_default_co]:
         """Apply a synchronous side effect with return type [trcks.Result][]
         to the wrapped [trcks.Success][] object.
@@ -1458,6 +1692,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.ResultWrapper][] instance with
@@ -1468,10 +1706,13 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
                 - *the original* [trcks.Success][]
                     if the applied side effect returns a [trcks.Success][].
         """
-        return ResultWrapper(r.tap_success_to_result(f)(self.core))
+        return ResultWrapper(r.tap_success_to_result(f, *args, **kwargs)(self.core))
 
     def tap_success_to_result_iterable(
-        self, f: Callable[[_S_default_co], ResultIterable[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultIterable[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Apply a synchronous side effect with return type [trcks.ResultIterable][]
         to the wrapped [trcks.Success][] object.
@@ -1480,6 +1721,10 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -1516,20 +1761,28 @@ class ResultWrapper(BaseWrapper[Result[_F_default_co, _S_default_co]]):
         """
         return ResultTupleWrapper.construct_from_result(
             self.core
-        ).tap_successes_to_result_iterable(f)
+        ).tap_successes_to_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_success_to_result_iterable instead")
     def tap_success_to_result_tuple(
-        self, f: Callable[[_S_default_co], ResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], ResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co | _F, _S_default_co]:
         """Deprecated alias for
         [trcks.oop.ResultWrapper.tap_success_to_result_iterable][].
         """
-        return self.tap_success_to_result_iterable(f)  # pragma: no cover
+        return self.tap_success_to_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_success_to_iterable instead")
     def tap_success_to_tuple(
-        self, f: Callable[[_S_default_co], tuple[object, ...]]
+        self,
+        f: Callable[Concatenate[_S_default_co, _P], tuple[object, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F_default_co, _S_default_co]:
         """Deprecated alias for [trcks.oop.ResultWrapper.tap_success_to_iterable][]."""
-        return self.tap_success_to_iterable(f)  # pragma: no cover
+        return self.tap_success_to_iterable(f, *args, **kwargs)  # pragma: no cover

--- a/src/trcks/oop/_tuple_wrapper.py
+++ b/src/trcks/oop/_tuple_wrapper.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, Concatenate, ParamSpec, final
 
 from trcks._typing import TypeVar, deprecated
 from trcks.fp.monads import tuple_ as t
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 __docformat__ = "google"
 
 _F = TypeVar("_F")
+_P = ParamSpec("_P")
 _S = TypeVar("_S")
 _T = TypeVar("_T")
 
@@ -127,12 +128,21 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         """Deprecated alias for construct_from_iterable."""
         return cls.construct_from_iterable(tpl)  # pragma: no cover
 
-    def map(self, f: Callable[[_T_co], _T]) -> TupleWrapper[_T]:
+    def map(
+        self,
+        f: Callable[Concatenate[_T_co, _P], _T],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> TupleWrapper[_T]:
         """Apply a synchronous function to each element in
         the wrapped homogeneous [tuple][].
 
         Args:
             f: The synchronous function to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.TupleWrapper][] instance with a homogeneous [tuple][]
@@ -151,16 +161,23 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
             >>> tuple_wrapper
             TupleWrapper(core=(2, 4, 6))
         """
-        return TupleWrapper(t.map_(f)(self.core))
+        return TupleWrapper(t.map_(f, *args, **kwargs)(self.core))
 
     def map_to_awaitable(
-        self, f: Callable[[_T_co], Awaitable[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Awaitable[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Apply an asynchronous function to each element in the wrapped
         homogeneous [tuple][].
 
         Args:
             f: The asynchronous function to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             An [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -186,10 +203,13 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         """
         return AwaitableTupleWrapper.construct_from_iterable(
             self.core
-        ).map_to_awaitable(f)
+        ).map_to_awaitable(f, *args, **kwargs)
 
     def map_to_awaitable_iterable(
-        self, f: Callable[[_T_co], AwaitableIterable[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableIterable[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Apply an asynchronous function returning a [trcks.AwaitableIterable][]
         to each element in the wrapped homogeneous [tuple][] and flatten.
@@ -197,6 +217,10 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         Args:
             f: The asynchronous function to be applied to each element,
                 returning a [trcks.AwaitableIterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             An [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -221,10 +245,13 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         """
         return AwaitableTupleWrapper.construct_from_iterable(
             self.core
-        ).map_to_awaitable_iterable(f)
+        ).map_to_awaitable_iterable(f, *args, **kwargs)
 
     def map_to_awaitable_result(
-        self, f: Callable[[_T_co], AwaitableResult[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResult[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S]:
         """Apply an asynchronous function with return type [trcks.Result][]
         to each element in the wrapped homogeneous [tuple][].
@@ -233,6 +260,10 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
 
         Args:
             f: The asynchronous function to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             An [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -277,10 +308,13 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         """
         return AwaitableResultTupleWrapper.construct_successes_from_iterable(
             self.core
-        ).map_successes_to_awaitable_result(f)
+        ).map_successes_to_awaitable_result(f, *args, **kwargs)
 
     def map_to_awaitable_result_iterable(
-        self, f: Callable[[_T_co], AwaitableResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S]:
         """Apply an asynchronous function with return type
         [trcks.AwaitableResultIterable][] to each element in the wrapped
@@ -290,6 +324,10 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
 
         Args:
             f: The asynchronous function to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             An [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -334,31 +372,48 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         """
         return AwaitableResultTupleWrapper.construct_successes_from_iterable(
             self.core
-        ).map_successes_to_awaitable_result_iterable(f)
+        ).map_successes_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_to_awaitable_result_iterable instead")
     def map_to_awaitable_result_tuple(
-        self, f: Callable[[_T_co], AwaitableResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S]:
         """Deprecated alias for
         [trcks.oop.TupleWrapper.map_to_awaitable_result_iterable][].
         """
-        return self.map_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.map_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_to_awaitable_iterable instead")
     def map_to_awaitable_tuple(
-        self, f: Callable[[_T_co], AwaitableTuple[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableTuple[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Deprecated alias for [trcks.oop.TupleWrapper.map_to_awaitable_iterable][]."""
-        return self.map_to_awaitable_iterable(f)  # pragma: no cover
+        return self.map_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
-    def map_to_iterable(self, f: Callable[[_T_co], Iterable[_T]]) -> TupleWrapper[_T]:
+    def map_to_iterable(
+        self,
+        f: Callable[Concatenate[_T_co, _P], Iterable[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> TupleWrapper[_T]:
         """Apply a function returning an [collections.abc.Iterable][] to each element
         in the wrapped homogeneous [tuple][] and flatten the result.
 
         Args:
             f: The function to be applied to each element,
                 returning an [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.TupleWrapper][] instance with
@@ -377,16 +432,23 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
             >>> tuple_wrapper
             TupleWrapper(core=(1, 1, 2, 2, 3, 3))
         """
-        return TupleWrapper(t.map_to_iterable(f)(self.core))
+        return TupleWrapper(t.map_to_iterable(f, *args, **kwargs)(self.core))
 
     def map_to_result(
-        self, f: Callable[[_T_co], Result[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Result[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _S]:
         """Apply a synchronous function with return type [trcks.Result][]
         to each element in the wrapped homogeneous [tuple][].
 
         Args:
             f: The synchronous function to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -415,16 +477,23 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         """
         return ResultTupleWrapper.construct_successes_from_iterable(
             self.core
-        ).map_successes_to_result(f)
+        ).map_successes_to_result(f, *args, **kwargs)
 
     def map_to_result_iterable(
-        self, f: Callable[[_T_co], ResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], ResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _S]:
         """Apply a synchronous function with return type [trcks.ResultIterable][]
         to each element in the wrapped homogeneous [tuple][] and flatten.
 
         Args:
             f: The synchronous function to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -453,26 +522,43 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         """
         return ResultTupleWrapper.construct_successes_from_iterable(
             self.core
-        ).map_successes_to_result_iterable(f)
+        ).map_successes_to_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use map_to_result_iterable instead")
     def map_to_result_tuple(
-        self, f: Callable[[_T_co], ResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], ResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _S]:
         """Deprecated alias for [trcks.oop.TupleWrapper.map_to_result_iterable][]."""
-        return self.map_to_result_iterable(f)  # pragma: no cover
+        return self.map_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
     @deprecated("Use map_to_iterable instead")
-    def map_to_tuple(self, f: Callable[[_T_co], tuple[_T, ...]]) -> TupleWrapper[_T]:
+    def map_to_tuple(
+        self,
+        f: Callable[Concatenate[_T_co, _P], tuple[_T, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> TupleWrapper[_T]:
         """Deprecated alias for [trcks.oop.TupleWrapper.map_to_iterable][]."""
-        return self.map_to_iterable(f)  # pragma: no cover
+        return self.map_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
-    def tap(self, f: Callable[[_T_co], object]) -> TupleWrapper[_T_co]:
+    def tap(
+        self,
+        f: Callable[Concatenate[_T_co, _P], object],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> TupleWrapper[_T_co]:
         """Apply a synchronous side effect to each element in the wrapped
         homogeneous [tuple][].
 
         Args:
             f: The synchronous side effect to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.TupleWrapper][] instance with
@@ -494,16 +580,23 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
             >>> tuple_wrapper
             TupleWrapper(core=(1, 2, 3))
         """
-        return TupleWrapper(t.tap(f)(self.core))
+        return TupleWrapper(t.tap(f, *args, **kwargs)(self.core))
 
     def tap_to_awaitable(
-        self, f: Callable[[_T_co], Awaitable[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Awaitable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Apply an asynchronous side effect to each element in the wrapped
         homogeneous [tuple][].
 
         Args:
             f: The asynchronous side effect to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             An [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -531,10 +624,13 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         """
         return AwaitableTupleWrapper.construct_from_iterable(
             self.core
-        ).tap_to_awaitable(f)
+        ).tap_to_awaitable(f, *args, **kwargs)
 
     def tap_to_awaitable_iterable(
-        self, f: Callable[[_T_co], AwaitableIterable[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableIterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Apply an asynchronous side effect returning a [trcks.AwaitableIterable][]
         to each element in the wrapped homogeneous [tuple][].
@@ -542,6 +638,10 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         Args:
             f: The asynchronous side effect to be applied to each element,
                 returning a [trcks.AwaitableIterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             An [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -570,16 +670,23 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         """
         return AwaitableTupleWrapper.construct_from_iterable(
             self.core
-        ).tap_to_awaitable_iterable(f)
+        ).tap_to_awaitable_iterable(f, *args, **kwargs)
 
     def tap_to_awaitable_result(
-        self, f: Callable[[_T_co], AwaitableResult[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResult[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _T_co]:
         """Apply an asynchronous side effect with return type [trcks.Result][]
         to each element in the wrapped homogeneous [tuple][].
 
         Args:
             f: The asynchronous side effect to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             An [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -625,10 +732,13 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         """
         return AwaitableResultTupleWrapper.construct_successes_from_iterable(
             self.core
-        ).tap_successes_to_awaitable_result(f)
+        ).tap_successes_to_awaitable_result(f, *args, **kwargs)
 
     def tap_to_awaitable_result_iterable(
-        self, f: Callable[[_T_co], AwaitableResultIterable[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResultIterable[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _T_co]:
         """Apply an asynchronous side effect with return type
         [trcks.AwaitableResultIterable][] to each element in the wrapped
@@ -636,6 +746,10 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
 
         Args:
             f: The asynchronous side effect to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             An [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -681,32 +795,47 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         """
         return AwaitableResultTupleWrapper.construct_successes_from_iterable(
             self.core
-        ).tap_successes_to_awaitable_result_iterable(f)
+        ).tap_successes_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_to_awaitable_result_iterable instead")
     def tap_to_awaitable_result_tuple(
-        self, f: Callable[[_T_co], AwaitableResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _T_co]:
         """Deprecated alias for
         [trcks.oop.TupleWrapper.tap_to_awaitable_result_iterable][].
         """
-        return self.tap_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.tap_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_to_awaitable_iterable instead")
     def tap_to_awaitable_tuple(
-        self, f: Callable[[_T_co], AwaitableTuple[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableTuple[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Deprecated alias for [trcks.oop.TupleWrapper.tap_to_awaitable_iterable][]."""
-        return self.tap_to_awaitable_iterable(f)  # pragma: no cover
+        return self.tap_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def tap_to_iterable(
-        self, f: Callable[[_T_co], Iterable[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Iterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> TupleWrapper[_T_co]:
         """Apply a side effect returning an [collections.abc.Iterable][] to each element
         in the wrapped homogeneous [tuple][].
 
         Args:
             f: The side effect to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.TupleWrapper][] instance with
@@ -726,16 +855,23 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
             >>> tuple_wrapper
             TupleWrapper(core=(1, 2, 2, 3, 3, 4, 4, 4))
         """
-        return TupleWrapper(t.tap_to_iterable(f)(self.core))
+        return TupleWrapper(t.tap_to_iterable(f, *args, **kwargs)(self.core))
 
     def tap_to_result(
-        self, f: Callable[[_T_co], Result[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Result[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _T_co]:
         """Apply a synchronous side effect with return type [trcks.Result][]
         to each element in the wrapped homogeneous [tuple][].
 
         Args:
             f: The synchronous side effect to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -766,16 +902,23 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         """
         return ResultTupleWrapper.construct_successes_from_iterable(
             self.core
-        ).tap_successes_to_result(f)
+        ).tap_successes_to_result(f, *args, **kwargs)
 
     def tap_to_result_iterable(
-        self, f: Callable[[_T_co], ResultIterable[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], ResultIterable[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _T_co]:
         """Apply a synchronous side effect with return type [trcks.ResultIterable][]
         to each element in the wrapped homogeneous [tuple][].
 
         Args:
             f: The synchronous side effect to be applied to each element.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -806,18 +949,24 @@ class TupleWrapper(BaseWrapper[tuple[_T_co, ...]]):
         """
         return ResultTupleWrapper.construct_successes_from_iterable(
             self.core
-        ).tap_successes_to_result_iterable(f)
+        ).tap_successes_to_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_to_result_iterable instead")
     def tap_to_result_tuple(
-        self, f: Callable[[_T_co], ResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], ResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _T_co]:
         """Deprecated alias for [trcks.oop.TupleWrapper.tap_to_result_iterable][]."""
-        return self.tap_to_result_iterable(f)  # pragma: no cover
+        return self.tap_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
     @deprecated("Use tap_to_iterable instead")
     def tap_to_tuple(
-        self, f: Callable[[_T_co], tuple[object, ...]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], tuple[object, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> TupleWrapper[_T_co]:
         """Deprecated alias for [trcks.oop.TupleWrapper.tap_to_iterable][]."""
-        return self.tap_to_iterable(f)  # pragma: no cover
+        return self.tap_to_iterable(f, *args, **kwargs)  # pragma: no cover

--- a/src/trcks/oop/_wrapper.py
+++ b/src/trcks/oop/_wrapper.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, Concatenate, ParamSpec, final
 
 from trcks._typing import TypeVar, deprecated
 from trcks.fp.monads import awaitable as a
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 __docformat__ = "google"
 
 _F = TypeVar("_F")
+_P = ParamSpec("_P")
 _S = TypeVar("_S")
 _T = TypeVar("_T")
 
@@ -85,11 +86,20 @@ class Wrapper(BaseWrapper[_T_co]):
         """
         return Wrapper(core=value)
 
-    def map(self, f: Callable[[_T_co], _T]) -> Wrapper[_T]:
+    def map(
+        self,
+        f: Callable[Concatenate[_T_co, _P], _T],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> Wrapper[_T]:
         """Apply a synchronous function to the wrapped object.
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.Wrapper][] instance
@@ -99,15 +109,22 @@ class Wrapper(BaseWrapper[_T_co]):
             >>> Wrapper.construct(5).map(lambda n: f"The number is {n}.")
             Wrapper(core='The number is 5.')
         """
-        return Wrapper(f(self.core))
+        return Wrapper(f(self.core, *args, **kwargs))
 
     def map_to_awaitable(
-        self, f: Callable[[_T_co], Awaitable[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Awaitable[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableWrapper[_T]:
         """Apply an asynchronous function to the wrapped object.
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableWrapper][] instance with
@@ -128,10 +145,13 @@ class Wrapper(BaseWrapper[_T_co]):
             >>> asyncio.run(awaitable_wrapper.core_as_coroutine)
             '3.14'
         """
-        return AwaitableWrapper(f(self.core))
+        return AwaitableWrapper(f(self.core, *args, **kwargs))
 
     def map_to_awaitable_iterable(
-        self, f: Callable[[_T_co], AwaitableIterable[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableIterable[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Apply an asynchronous function returning a [collections.abc.Iterable][]
         to the wrapped object.
@@ -139,6 +159,10 @@ class Wrapper(BaseWrapper[_T_co]):
         Args:
             f: The asynchronous function to be applied, returning a
                 [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -162,16 +186,23 @@ class Wrapper(BaseWrapper[_T_co]):
             >>> asyncio.run(main())
             (7, 7)
         """
-        return AwaitableTupleWrapper(a.map_(tuple)(f(self.core)))
+        return AwaitableTupleWrapper(a.map_(tuple)(f(self.core, *args, **kwargs)))
 
     def map_to_awaitable_result(
-        self, f: Callable[[_T_co], AwaitableResult[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResult[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F, _S]:
         """Apply an asynchronous function with return type [trcks.Result][]
         to the wrapped object.
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance with
@@ -199,16 +230,23 @@ class Wrapper(BaseWrapper[_T_co]):
             >>> asyncio.run(awaitable_result_wrapper.core_as_coroutine)
             ('success', 42.0)
         """
-        return AwaitableResultWrapper(f(self.core))
+        return AwaitableResultWrapper(f(self.core, *args, **kwargs))
 
     def map_to_awaitable_result_iterable(
-        self, f: Callable[[_T_co], AwaitableResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S]:
         """Apply an asynchronous function with return type
         [trcks.AwaitableResultIterable][] to the wrapped object.
 
         Args:
             f: The asynchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -234,30 +272,49 @@ class Wrapper(BaseWrapper[_T_co]):
             >>> asyncio.run(wrapper.core_as_coroutine)
             ('success', (5.0, 10.0))
         """
-        return AwaitableResultTupleWrapper(ar.map_success(tuple)(f(self.core)))
+        return AwaitableResultTupleWrapper(
+            ar.map_success(tuple)(f(self.core, *args, **kwargs))
+        )
 
     @deprecated("Use map_to_awaitable_result_iterable instead")
     def map_to_awaitable_result_tuple(
-        self, f: Callable[[_T_co], AwaitableResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _S]:
         """Deprecated alias for
         [trcks.oop.Wrapper.map_to_awaitable_result_iterable][].
         """
-        return self.map_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.map_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use map_to_awaitable_iterable instead")
     def map_to_awaitable_tuple(
-        self, f: Callable[[_T_co], AwaitableTuple[_T]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableTuple[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T]:
         """Deprecated alias for [trcks.oop.Wrapper.map_to_awaitable_iterable][]."""
-        return self.map_to_awaitable_iterable(f)  # pragma: no cover
+        return self.map_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
-    def map_to_iterable(self, f: Callable[[_T_co], Iterable[_T]]) -> TupleWrapper[_T]:
+    def map_to_iterable(
+        self,
+        f: Callable[Concatenate[_T_co, _P], Iterable[_T]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> TupleWrapper[_T]:
         """Apply a function returning an [collections.abc.Iterable][]
         to the wrapped object.
 
         Args:
             f: The function to be applied, returning a [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.TupleWrapper][] instance with
@@ -271,16 +328,23 @@ class Wrapper(BaseWrapper[_T_co]):
             >>> Wrapper.construct(3).map_to_iterable(duplicate)
             TupleWrapper(core=(3, 3))
         """
-        return TupleWrapper(tuple(f(self.core)))
+        return TupleWrapper(tuple(f(self.core, *args, **kwargs)))
 
     def map_to_result(
-        self, f: Callable[[_T_co], Result[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Result[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultWrapper[_F, _S]:
         """Apply a synchronous function with return type [trcks.Result][]
         to the wrapped object.
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultWrapper][] instance with
@@ -294,16 +358,23 @@ class Wrapper(BaseWrapper[_T_co]):
             ... )
             ResultWrapper(core=('failure', 'negative value'))
         """
-        return ResultWrapper(f(self.core))
+        return ResultWrapper(f(self.core, *args, **kwargs))
 
     def map_to_result_iterable(
-        self, f: Callable[[_T_co], ResultIterable[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], ResultIterable[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _S]:
         """Apply a synchronous function with return type [trcks.ResultIterable][]
         to the wrapped object.
 
         Args:
             f: The synchronous function to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -318,25 +389,42 @@ class Wrapper(BaseWrapper[_T_co]):
             ... )
             ResultTupleWrapper(core=('failure', 'negative value'))
         """
-        return ResultTupleWrapper(r.map_success(tuple)(f(self.core)))
+        return ResultTupleWrapper(r.map_success(tuple)(f(self.core, *args, **kwargs)))
 
     @deprecated("Use map_to_result_iterable instead")
     def map_to_result_tuple(
-        self, f: Callable[[_T_co], ResultTuple[_F, _S]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], ResultTuple[_F, _S]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _S]:
         """Deprecated alias for [trcks.oop.Wrapper.map_to_result_iterable][]."""
-        return self.map_to_result_iterable(f)  # pragma: no cover
+        return self.map_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
     @deprecated("Use map_to_iterable instead")
-    def map_to_tuple(self, f: Callable[[_T_co], tuple[_T, ...]]) -> TupleWrapper[_T]:
+    def map_to_tuple(
+        self,
+        f: Callable[Concatenate[_T_co, _P], tuple[_T, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> TupleWrapper[_T]:
         """Deprecated alias for [trcks.oop.Wrapper.map_to_iterable][]."""
-        return self.map_to_iterable(f)  # pragma: no cover
+        return self.map_to_iterable(f, *args, **kwargs)  # pragma: no cover
 
-    def tap(self, f: Callable[[_T_co], object]) -> Wrapper[_T_co]:
+    def tap(
+        self,
+        f: Callable[Concatenate[_T_co, _P], object],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> Wrapper[_T_co]:
         """Apply a synchronous side effect to the wrapped object.
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A new [trcks.oop.Wrapper][] instance with the original wrapped object,
@@ -348,15 +436,22 @@ class Wrapper(BaseWrapper[_T_co]):
             >>> wrapper
             Wrapper(core=5)
         """
-        return self.map(i.tap(f))
+        return self.map(i.tap(f, *args, **kwargs))
 
     def tap_to_awaitable(
-        self, f: Callable[[_T_co], Awaitable[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Awaitable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableWrapper[_T_co]:
         """Apply an asynchronous side effect to the wrapped object.
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableWrapper][] instance with the original wrapped object.
@@ -378,10 +473,15 @@ class Wrapper(BaseWrapper[_T_co]):
             >>> value
             'Hello, world!'
         """
-        return AwaitableWrapper.construct(self.core).tap_to_awaitable(f)
+        return AwaitableWrapper.construct(self.core).tap_to_awaitable(
+            f, *args, **kwargs
+        )
 
     def tap_to_awaitable_iterable(
-        self, f: Callable[[_T_co], AwaitableIterable[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableIterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Apply an asynchronous side effect returning a [trcks.AwaitableIterable][]
         to the wrapped object.
@@ -389,6 +489,10 @@ class Wrapper(BaseWrapper[_T_co]):
         Args:
             f: The asynchronous side effect to be applied,
                 returning a [trcks.AwaitableIterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableTupleWrapper][] instance with
@@ -410,16 +514,25 @@ class Wrapper(BaseWrapper[_T_co]):
             Wrote 3 to disk.
             (3, 3)
         """
-        return AwaitableTupleWrapper.construct(self.core).tap_to_awaitable_iterable(f)
+        return AwaitableTupleWrapper.construct(self.core).tap_to_awaitable_iterable(
+            f, *args, **kwargs
+        )
 
     def tap_to_awaitable_result(
-        self, f: Callable[[_T_co], AwaitableResult[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResult[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultWrapper[_F, _T_co]:
         """Apply an asynchronous side effect with return type [trcks.Result][]
         to the wrapped object.
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultWrapper][] instance with
@@ -464,16 +577,23 @@ class Wrapper(BaseWrapper[_T_co]):
         """
         return AwaitableResultWrapper.construct_success(
             self.core
-        ).tap_success_to_awaitable_result(f)
+        ).tap_success_to_awaitable_result(f, *args, **kwargs)
 
     def tap_to_awaitable_result_iterable(
-        self, f: Callable[[_T_co], AwaitableResultIterable[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResultIterable[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _T_co]:
         """Apply an asynchronous side effect with return type
         [trcks.AwaitableResultIterable][] to the wrapped object.
 
         Args:
             f: The asynchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.AwaitableResultTupleWrapper][] instance with
@@ -507,26 +627,37 @@ class Wrapper(BaseWrapper[_T_co]):
         """
         return AwaitableResultTupleWrapper.construct_successes(
             self.core
-        ).tap_successes_to_awaitable_result_iterable(f)
+        ).tap_successes_to_awaitable_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_to_awaitable_result_iterable instead")
     def tap_to_awaitable_result_tuple(
-        self, f: Callable[[_T_co], AwaitableResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableResultTupleWrapper[_F, _T_co]:
         """Deprecated alias for
         [trcks.oop.Wrapper.tap_to_awaitable_result_iterable][].
         """
-        return self.tap_to_awaitable_result_iterable(f)  # pragma: no cover
+        return self.tap_to_awaitable_result_iterable(
+            f, *args, **kwargs
+        )  # pragma: no cover
 
     @deprecated("Use tap_to_awaitable_iterable instead")
     def tap_to_awaitable_tuple(
-        self, f: Callable[[_T_co], AwaitableTuple[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], AwaitableTuple[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> AwaitableTupleWrapper[_T_co]:
         """Deprecated alias for [trcks.oop.Wrapper.tap_to_awaitable_iterable][]."""
-        return self.tap_to_awaitable_iterable(f)  # pragma: no cover
+        return self.tap_to_awaitable_iterable(f, *args, **kwargs)  # pragma: no cover
 
     def tap_to_iterable(
-        self, f: Callable[[_T_co], Iterable[object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Iterable[object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> TupleWrapper[_T_co]:
         """Apply a side effect returning an [collections.abc.Iterable][] to the
         wrapped object.
@@ -534,6 +665,10 @@ class Wrapper(BaseWrapper[_T_co]):
         Args:
             f: The side effect to be applied, returning an
                 [collections.abc.Iterable][].
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.TupleWrapper][] instance with the original wrapped
@@ -549,16 +684,23 @@ class Wrapper(BaseWrapper[_T_co]):
             Wrote 3 to disk.
             TupleWrapper(core=(3, 3))
         """
-        return TupleWrapper.construct(self.core).tap_to_iterable(f)
+        return TupleWrapper.construct(self.core).tap_to_iterable(f, *args, **kwargs)
 
     def tap_to_result(
-        self, f: Callable[[_T_co], Result[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], Result[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultWrapper[_F, _T_co]:
         """Apply a synchronous side effect with return type [trcks.Result][]
         to the wrapped object.
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultWrapper][] instance with
@@ -588,16 +730,25 @@ class Wrapper(BaseWrapper[_T_co]):
             >>> result_wrapper_2
             ResultWrapper(core=('success', 3.5))
         """
-        return ResultWrapper.construct_success(self.core).tap_success_to_result(f)
+        return ResultWrapper.construct_success(self.core).tap_success_to_result(
+            f, *args, **kwargs
+        )
 
     def tap_to_result_iterable(
-        self, f: Callable[[_T_co], ResultIterable[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], ResultIterable[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _T_co]:
         """Apply a synchronous side effect with return type [trcks.ResultIterable][]
         to the wrapped object.
 
         Args:
             f: The synchronous side effect to be applied.
+            *args:
+                Positional arguments to be passed to `f`.
+            **kwargs:
+                Keyword arguments to be passed to `f`.
 
         Returns:
             A [trcks.oop.ResultTupleWrapper][] instance with
@@ -633,18 +784,24 @@ class Wrapper(BaseWrapper[_T_co]):
         """
         return ResultTupleWrapper.construct_successes(
             self.core
-        ).tap_successes_to_result_iterable(f)
+        ).tap_successes_to_result_iterable(f, *args, **kwargs)
 
     @deprecated("Use tap_to_result_iterable instead")
     def tap_to_result_tuple(
-        self, f: Callable[[_T_co], ResultTuple[_F, object]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], ResultTuple[_F, object]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> ResultTupleWrapper[_F, _T_co]:
         """Deprecated alias for [trcks.oop.Wrapper.tap_to_result_iterable][]."""
-        return self.tap_to_result_iterable(f)  # pragma: no cover
+        return self.tap_to_result_iterable(f, *args, **kwargs)  # pragma: no cover
 
     @deprecated("Use tap_to_iterable instead")
     def tap_to_tuple(
-        self, f: Callable[[_T_co], tuple[object, ...]]
+        self,
+        f: Callable[Concatenate[_T_co, _P], tuple[object, ...]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
     ) -> TupleWrapper[_T_co]:
         """Deprecated alias for [trcks.oop.Wrapper.tap_to_iterable][]."""
-        return self.tap_to_iterable(f)  # pragma: no cover
+        return self.tap_to_iterable(f, *args, **kwargs)  # pragma: no cover

--- a/tests/trcks/fp/monads/test_awaitable.py
+++ b/tests/trcks/fp/monads/test_awaitable.py
@@ -1,0 +1,31 @@
+from collections.abc import Awaitable, Callable
+from typing import TypeAlias
+from unittest.mock import AsyncMock, Mock
+
+from trcks.fp.monads import awaitable as a
+
+_MappedFunction: TypeAlias = Callable[[Awaitable[str]], Awaitable[str]]
+
+
+async def test_map_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value="mapped")
+    mapped: _MappedFunction = a.map_(probe, "extra", extra_kw="kw")
+    output = await mapped(a.construct("input"))
+    assert output == "mapped"
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+
+async def test_map_to_awaitable_forwards_args_and_kwargs() -> None:
+    probe = AsyncMock(return_value="mapped")
+    mapped: _MappedFunction = a.map_to_awaitable(probe, "extra", extra_kw="kw")
+    output = await mapped(a.construct("input"))
+    assert output == "mapped"
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+
+async def test_tap_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value=None)
+    tapped: _MappedFunction = a.tap(probe, "extra", extra_kw="kw")
+    output = await tapped(a.construct("input"))
+    assert output == "input"
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")

--- a/tests/trcks/fp/monads/test_awaitable_result.py
+++ b/tests/trcks/fp/monads/test_awaitable_result.py
@@ -1,0 +1,36 @@
+from collections.abc import Callable
+from typing import TypeAlias
+from unittest.mock import AsyncMock, Mock
+
+from trcks import AwaitableResult
+from trcks.fp.monads import awaitable_result as ar
+
+_MappedFunction: TypeAlias = Callable[
+    [AwaitableResult[object, str]], AwaitableResult[object, str]
+]
+
+
+async def test_map_success_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value="mapped")
+    mapped: _MappedFunction = ar.map_success(probe, "extra", extra_kw="kw")
+    output = await mapped(ar.construct_success("input"))
+    assert output == ("success", "mapped")
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+
+async def test_map_success_to_awaitable_result_forwards_args_and_kwargs() -> None:
+    probe = AsyncMock(return_value=("success", "mapped"))
+    mapped: _MappedFunction = ar.map_success_to_awaitable_result(
+        probe, "extra", extra_kw="kw"
+    )
+    output = await mapped(ar.construct_success("input"))
+    assert output == ("success", "mapped")
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+
+async def test_tap_success_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value=None)
+    tapped: _MappedFunction = ar.tap_success(probe, "extra", extra_kw="kw")
+    output = await tapped(ar.construct_success("input"))
+    assert output == ("success", "input")
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")

--- a/tests/trcks/fp/monads/test_awaitable_result_tuple.py
+++ b/tests/trcks/fp/monads/test_awaitable_result_tuple.py
@@ -1,0 +1,26 @@
+from collections.abc import Callable
+from typing import TypeAlias
+from unittest.mock import Mock
+
+from trcks import AwaitableResultTuple
+from trcks.fp.monads import awaitable_result_tuple as art
+
+_MappedFunction: TypeAlias = Callable[
+    [AwaitableResultTuple[object, str]], AwaitableResultTuple[object, str]
+]
+
+
+async def test_map_successes_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value="mapped")
+    mapped: _MappedFunction = art.map_successes(probe, "extra", extra_kw="kw")
+    output = await mapped(art.construct_successes("input"))
+    assert output == ("success", ("mapped",))
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+
+async def test_tap_successes_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value=None)
+    tapped: _MappedFunction = art.tap_successes(probe, "extra", extra_kw="kw")
+    output = await tapped(art.construct_successes("input"))
+    assert output == ("success", ("input",))
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")

--- a/tests/trcks/fp/monads/test_awaitable_tuple.py
+++ b/tests/trcks/fp/monads/test_awaitable_tuple.py
@@ -1,0 +1,24 @@
+from collections.abc import Callable
+from typing import TypeAlias
+from unittest.mock import Mock
+
+from trcks import AwaitableTuple
+from trcks.fp.monads import awaitable_tuple as at
+
+_MappedFunction: TypeAlias = Callable[[AwaitableTuple[str]], AwaitableTuple[str]]
+
+
+async def test_map_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value="mapped")
+    mapped: _MappedFunction = at.map_(probe, "extra", extra_kw="kw")
+    output = await mapped(at.construct("input"))
+    assert output == ("mapped",)
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+
+async def test_tap_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value=None)
+    tapped: _MappedFunction = at.tap(probe, "extra", extra_kw="kw")
+    output = await tapped(at.construct("input"))
+    assert output == ("input",)
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")

--- a/tests/trcks/fp/monads/test_identity.py
+++ b/tests/trcks/fp/monads/test_identity.py
@@ -1,0 +1,15 @@
+from collections.abc import Callable
+from typing import TypeAlias
+from unittest.mock import Mock
+
+from trcks.fp.monads import identity as i
+
+_MappedFunction: TypeAlias = Callable[[str], str]
+
+
+def test_tap_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value=None)
+    tapped: _MappedFunction = i.tap(probe, "extra", extra_kw="kw")
+    output = tapped("input")
+    assert output == "input"
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")

--- a/tests/trcks/fp/monads/test_result.py
+++ b/tests/trcks/fp/monads/test_result.py
@@ -1,0 +1,29 @@
+from collections.abc import Callable
+from typing import TypeAlias
+from unittest.mock import Mock
+
+from trcks import Result
+from trcks.fp.monads import result as r
+
+_MappedFunction: TypeAlias = Callable[[Result[object, str]], Result[object, str]]
+
+
+def test_map_success_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value="mapped")
+    mapped: _MappedFunction = r.map_success(probe, "extra", extra_kw="kw")
+    assert mapped(("success", "input")) == ("success", "mapped")
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+
+def test_map_success_to_result_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value=("success", "mapped"))
+    mapped: _MappedFunction = r.map_success_to_result(probe, "extra", extra_kw="kw")
+    assert mapped(("success", "input")) == ("success", "mapped")
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+
+def test_tap_success_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value=None)
+    tapped: _MappedFunction = r.tap_success(probe, "extra", extra_kw="kw")
+    assert tapped(("success", "input")) == ("success", "input")
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")

--- a/tests/trcks/fp/monads/test_result_tuple.py
+++ b/tests/trcks/fp/monads/test_result_tuple.py
@@ -1,0 +1,24 @@
+from collections.abc import Callable
+from typing import TypeAlias
+from unittest.mock import Mock
+
+from trcks import ResultTuple
+from trcks.fp.monads import result_tuple as rt
+
+_MappedFunction: TypeAlias = Callable[
+    [ResultTuple[object, str]], ResultTuple[object, str]
+]
+
+
+def test_map_successes_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value="mapped")
+    mapped: _MappedFunction = rt.map_successes(probe, "extra", extra_kw="kw")
+    assert mapped(("success", ("input",))) == ("success", ("mapped",))
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+
+def test_tap_successes_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value=None)
+    tapped: _MappedFunction = rt.tap_successes(probe, "extra", extra_kw="kw")
+    assert tapped(("success", ("input",))) == ("success", ("input",))
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")

--- a/tests/trcks/fp/monads/test_tuple_.py
+++ b/tests/trcks/fp/monads/test_tuple_.py
@@ -1,0 +1,21 @@
+from collections.abc import Callable
+from typing import TypeAlias
+from unittest.mock import Mock
+
+from trcks.fp.monads import tuple_ as t
+
+_MappedFunction: TypeAlias = Callable[[tuple[str, ...]], tuple[str, ...]]
+
+
+def test_map_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value="mapped")
+    mapped: _MappedFunction = t.map_(probe, "extra", extra_kw="kw")
+    assert mapped(("input",)) == ("mapped",)
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+
+def test_tap_forwards_args_and_kwargs() -> None:
+    probe = Mock(return_value=None)
+    tapped: _MappedFunction = t.tap(probe, "extra", extra_kw="kw")
+    assert tapped(("input",)) == ("input",)
+    probe.assert_called_once_with("input", "extra", extra_kw="kw")

--- a/tests/trcks/test_map_tap_signatures.py
+++ b/tests/trcks/test_map_tap_signatures.py
@@ -1,0 +1,102 @@
+import inspect
+from types import FunctionType
+from typing import Final, TypeAlias
+
+import pytest
+
+from trcks.fp.monads import (
+    awaitable,
+    awaitable_result,
+    awaitable_result_tuple,
+    awaitable_tuple,
+    identity,
+    result,
+    result_tuple,
+    tuple_,
+)
+from trcks.oop import (
+    AwaitableResultTupleWrapper,
+    AwaitableResultWrapper,
+    AwaitableTupleWrapper,
+    AwaitableWrapper,
+    ResultTupleWrapper,
+    ResultWrapper,
+    TupleWrapper,
+    Wrapper,
+)
+
+CollectedFunctions: TypeAlias = list[tuple[str, FunctionType]]
+
+
+def _assert_accepts_args_and_kwargs(name: str, function_: FunctionType) -> None:
+    kinds = {
+        parameter.kind for parameter in inspect.signature(function_).parameters.values()
+    }
+    assert inspect.Parameter.VAR_POSITIONAL in kinds, f"{name} does not accept *args"
+    assert inspect.Parameter.VAR_KEYWORD in kinds, f"{name} does not accept **kwargs"
+
+
+def _collect_functions() -> CollectedFunctions:
+    modules = (
+        awaitable,
+        awaitable_result,
+        awaitable_result_tuple,
+        awaitable_tuple,
+        identity,
+        result,
+        result_tuple,
+        tuple_,
+    )
+    return [
+        (f"{module.__name__}.{name}", function)
+        for module in modules
+        for name, function in inspect.getmembers(module, inspect.isfunction)
+        if name.startswith(("map", "tap")) and function.__module__ == module.__name__
+    ]
+
+
+def _collect_methods() -> CollectedFunctions:
+    classes = (
+        Wrapper,
+        AwaitableWrapper,
+        ResultWrapper,
+        TupleWrapper,
+        AwaitableTupleWrapper,
+        AwaitableResultWrapper,
+        ResultTupleWrapper,
+        AwaitableResultTupleWrapper,
+    )
+    return [
+        (f"{cls.__qualname__}.{name}", method)
+        for cls in classes
+        for name, method in inspect.getmembers(cls, inspect.isfunction)
+        if name.startswith(("map", "tap"))
+    ]
+
+
+_FUNCTIONS: Final = _collect_functions()
+_METHODS: Final = _collect_methods()
+
+
+@pytest.mark.parametrize(
+    ("name", "function"),
+    [pytest.param(name, function, id=name) for name, function in _FUNCTIONS],
+)
+def test_function_forwards_args_and_kwargs(name: str, function: FunctionType) -> None:
+    _assert_accepts_args_and_kwargs(name, function)
+
+
+@pytest.mark.parametrize(
+    ("name", "method"),
+    [pytest.param(name, method, id=name) for name, method in _METHODS],
+)
+def test_method_forwards_args_and_kwargs(name: str, method: FunctionType) -> None:
+    _assert_accepts_args_and_kwargs(name, method)
+
+
+def test_more_than_fifty_functions_were_collected() -> None:
+    assert len(_FUNCTIONS) > 50  # noqa: PLR2004
+
+
+def test_more_than_fifty_methods_were_collected() -> None:
+    assert len(_METHODS) > 50  # noqa: PLR2004

--- a/tests/trcks/test_oop.py
+++ b/tests/trcks/test_oop.py
@@ -56,53 +56,6 @@ async def _stringify_slowly(o: object) -> str:
     return str(o)
 
 
-class TestAwaitableWrapper:
-    @pytest.mark.parametrize("value", _OBJECTS)
-    async def test_awaitable_wrapper_wraps_awaitable(self, value: object) -> None:
-        awaitable = asyncio.create_task(asyncio.sleep(0.001, result=value))
-        assert AwaitableWrapper(awaitable).core is awaitable
-
-    @pytest.mark.parametrize("value", _OBJECTS)
-    async def test_construct_wraps_value(self, value: object) -> None:
-        assert await AwaitableWrapper.construct(value).core == value
-
-    @pytest.mark.parametrize("value", _OBJECTS)
-    async def test_construct_from_awaitable_wraps_awaitable(
-        self, value: object
-    ) -> None:
-        awaitable = asyncio.create_task(asyncio.sleep(0.001, result=value))
-        assert AwaitableWrapper.construct_from_awaitable(awaitable).core is awaitable
-
-    async def test_core_as_coroutine_is_coroutine(self) -> None:
-        core_as_coroutine = AwaitableWrapper.construct(1).core_as_coroutine
-        assert isinstance(core_as_coroutine, Coroutine)
-        assert await core_as_coroutine == 1
-
-    @pytest.mark.parametrize("value", _FLOATS)
-    async def test_map_maps_value(self, value: float) -> None:
-        assert await AwaitableWrapper.construct(value).map(_double).core == _double(
-            value
-        )
-
-    @pytest.mark.parametrize("value", _FLOATS)
-    async def test_map_to_awaitable_maps_value(self, value: float) -> None:
-        assert await AwaitableWrapper.construct(value).map_to_awaitable(
-            _double_slowly
-        ).core == await _double_slowly(value)
-
-    @pytest.mark.parametrize("value", _FLOATS)
-    async def test_map_to_awaitable_result_maps_value(self, value: float) -> None:
-        assert await AwaitableWrapper.construct(value).map_to_awaitable_result(
-            _get_square_root_safely_and_slowly
-        ).core == await _get_square_root_safely_and_slowly(value)
-
-    @pytest.mark.parametrize("value", _FLOATS)
-    async def test_map_to_result_maps_maps_value(self, value: float) -> None:
-        assert await AwaitableWrapper.construct(value).map_to_result(
-            _get_square_root_safely
-        ).core == _get_square_root_safely(value)
-
-
 class TestAwaitableResultWrapper:
     @pytest.mark.parametrize("result", _RESULTS)
     async def test_awaitable_result_wrapper_wraps_awaitable_result(
@@ -112,18 +65,18 @@ class TestAwaitableResultWrapper:
         assert AwaitableResultWrapper(awaitable_result).core is awaitable_result
 
     @pytest.mark.parametrize("value", _OBJECTS)
-    async def test_construct_failure_wraps_value(self, value: object) -> None:
-        awaited_core = await AwaitableResultWrapper.construct_failure(value).core
-        assert awaited_core[0] == "failure"
-        assert awaited_core[1] is value
-
-    @pytest.mark.parametrize("value", _OBJECTS)
     async def test_construct_failure_from_awaitable_wraps_value(
         self, value: object
     ) -> None:
         awaited_core = await AwaitableResultWrapper.construct_failure_from_awaitable(
             asyncio.create_task(asyncio.sleep(0.001, result=value))
         ).core
+        assert awaited_core[0] == "failure"
+        assert awaited_core[1] is value
+
+    @pytest.mark.parametrize("value", _OBJECTS)
+    async def test_construct_failure_wraps_value(self, value: object) -> None:
+        awaited_core = await AwaitableResultWrapper.construct_failure(value).core
         assert awaited_core[0] == "failure"
         assert awaited_core[1] is value
 
@@ -146,18 +99,18 @@ class TestAwaitableResultWrapper:
         assert await AwaitableResultWrapper.construct_from_result(result).core is result
 
     @pytest.mark.parametrize("value", _OBJECTS)
-    async def test_construct_success_wraps_value(self, value: object) -> None:
-        awaited_core = await AwaitableResultWrapper.construct_success(value).core
-        assert awaited_core[0] == "success"
-        assert awaited_core[1] is value
-
-    @pytest.mark.parametrize("value", _OBJECTS)
     async def test_construct_success_from_awaitable_wraps_value(
         self, value: object
     ) -> None:
         awaited_core = await AwaitableResultWrapper.construct_success_from_awaitable(
             asyncio.create_task(asyncio.sleep(0.001, result=value))
         ).core
+        assert awaited_core[0] == "success"
+        assert awaited_core[1] is value
+
+    @pytest.mark.parametrize("value", _OBJECTS)
+    async def test_construct_success_wraps_value(self, value: object) -> None:
+        awaited_core = await AwaitableResultWrapper.construct_success(value).core
         assert awaited_core[0] == "success"
         assert awaited_core[1] is value
 
@@ -331,43 +284,54 @@ class TestAwaitableResultWrapper:
         ).core == _get_square_root_safely(value)
 
 
-class TestWrapper:
+class TestAwaitableWrapper:
     @pytest.mark.parametrize("value", _OBJECTS)
-    def test_wrapper_wraps_value(self, value: object) -> None:
-        assert Wrapper(value).core is value
+    async def test_awaitable_wrapper_wraps_awaitable(self, value: object) -> None:
+        awaitable = asyncio.create_task(asyncio.sleep(0.001, result=value))
+        assert AwaitableWrapper(awaitable).core is awaitable
 
     @pytest.mark.parametrize("value", _OBJECTS)
-    def test_construct_wraps_value(self, value: object) -> None:
-        assert Wrapper.construct(value).core is value
+    async def test_construct_from_awaitable_wraps_awaitable(
+        self, value: object
+    ) -> None:
+        awaitable = asyncio.create_task(asyncio.sleep(0.001, result=value))
+        assert AwaitableWrapper.construct_from_awaitable(awaitable).core is awaitable
+
+    @pytest.mark.parametrize("value", _OBJECTS)
+    async def test_construct_wraps_value(self, value: object) -> None:
+        assert await AwaitableWrapper.construct(value).core == value
+
+    async def test_core_as_coroutine_is_coroutine(self) -> None:
+        core_as_coroutine = AwaitableWrapper.construct(1).core_as_coroutine
+        assert isinstance(core_as_coroutine, Coroutine)
+        assert await core_as_coroutine == 1
 
     @pytest.mark.parametrize("value", _FLOATS)
-    def test_map_maps_value(self, value: float) -> None:
-        assert Wrapper(value).map(_double).core == _double(value)
-
-    @pytest.mark.parametrize("value", _OBJECTS)
-    async def test_map_to_awaitable_maps_value(self, value: object) -> None:
-        assert await Wrapper(value).map_to_awaitable(
-            _stringify_slowly
-        ).core == await _stringify_slowly(value)
+    async def test_map_maps_value(self, value: float) -> None:
+        assert await AwaitableWrapper.construct(value).map(_double).core == _double(
+            value
+        )
 
     @pytest.mark.parametrize("value", _FLOATS)
-    def test_map_to_result_maps_value(self, value: float) -> None:
-        assert Wrapper(value).map_to_result(
-            _get_square_root_safely
-        ).core == _get_square_root_safely(value)
+    async def test_map_to_awaitable_maps_value(self, value: float) -> None:
+        assert await AwaitableWrapper.construct(value).map_to_awaitable(
+            _double_slowly
+        ).core == await _double_slowly(value)
 
     @pytest.mark.parametrize("value", _FLOATS)
     async def test_map_to_awaitable_result_maps_value(self, value: float) -> None:
-        assert await Wrapper(value).map_to_awaitable_result(
+        assert await AwaitableWrapper.construct(value).map_to_awaitable_result(
             _get_square_root_safely_and_slowly
         ).core == await _get_square_root_safely_and_slowly(value)
 
+    @pytest.mark.parametrize("value", _FLOATS)
+    async def test_map_to_result_maps_maps_value(self, value: float) -> None:
+        assert await AwaitableWrapper.construct(value).map_to_result(
+            _get_square_root_safely
+        ).core == _get_square_root_safely(value)
+
 
 class TestResultWrapper:
-    @pytest.mark.parametrize("result", _RESULTS)
-    def test_result_wrapper_wraps_result(self, result: Result[object, object]) -> None:
-        assert ResultWrapper(result).core is result
-
     @pytest.mark.parametrize("value", _OBJECTS)
     def test_construct_failure_wraps_value(self, value: object) -> None:
         result_wrapper = ResultWrapper.construct_failure(value)
@@ -523,3 +487,39 @@ class TestResultWrapper:
         assert ResultWrapper.construct_success(value).map_success_to_result(
             _get_square_root_safely
         ).core == _get_square_root_safely(value)
+
+    @pytest.mark.parametrize("result", _RESULTS)
+    def test_result_wrapper_wraps_result(self, result: Result[object, object]) -> None:
+        assert ResultWrapper(result).core is result
+
+
+class TestWrapper:
+    @pytest.mark.parametrize("value", _OBJECTS)
+    def test_construct_wraps_value(self, value: object) -> None:
+        assert Wrapper.construct(value).core is value
+
+    @pytest.mark.parametrize("value", _FLOATS)
+    def test_map_maps_value(self, value: float) -> None:
+        assert Wrapper(value).map(_double).core == _double(value)
+
+    @pytest.mark.parametrize("value", _OBJECTS)
+    async def test_map_to_awaitable_maps_value(self, value: object) -> None:
+        assert await Wrapper(value).map_to_awaitable(
+            _stringify_slowly
+        ).core == await _stringify_slowly(value)
+
+    @pytest.mark.parametrize("value", _FLOATS)
+    async def test_map_to_awaitable_result_maps_value(self, value: float) -> None:
+        assert await Wrapper(value).map_to_awaitable_result(
+            _get_square_root_safely_and_slowly
+        ).core == await _get_square_root_safely_and_slowly(value)
+
+    @pytest.mark.parametrize("value", _FLOATS)
+    def test_map_to_result_maps_value(self, value: float) -> None:
+        assert Wrapper(value).map_to_result(
+            _get_square_root_safely
+        ).core == _get_square_root_safely(value)
+
+    @pytest.mark.parametrize("value", _OBJECTS)
+    def test_wrapper_wraps_value(self, value: object) -> None:
+        assert Wrapper(value).core is value

--- a/tests/trcks/test_oop.py
+++ b/tests/trcks/test_oop.py
@@ -2,11 +2,21 @@ import asyncio
 import math
 from collections.abc import Callable, Coroutine
 from typing import Final, Literal
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from trcks import Result
-from trcks.oop import AwaitableResultWrapper, AwaitableWrapper, ResultWrapper, Wrapper
+from trcks.oop import (
+    AwaitableResultTupleWrapper,
+    AwaitableResultWrapper,
+    AwaitableTupleWrapper,
+    AwaitableWrapper,
+    ResultTupleWrapper,
+    ResultWrapper,
+    TupleWrapper,
+    Wrapper,
+)
 
 _TO_PAIR: Final[Callable[[int], tuple[int, int]]] = lambda n: (n, n)  # noqa: E731
 
@@ -54,6 +64,28 @@ async def _get_square_root_safely_and_slowly(
 async def _stringify_slowly(o: object) -> str:
     await asyncio.sleep(0.001)
     return str(o)
+
+
+class TestAwaitableResultTupleWrapper:
+    async def test_map_successes_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value="mapped")
+        output = (
+            await AwaitableResultTupleWrapper.construct_successes("input")
+            .map_successes(probe, "extra", extra_kw="kw")
+            .core
+        )
+        assert output == ("success", ("mapped",))
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+    async def test_tap_successes_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value=None)
+        output = (
+            await AwaitableResultTupleWrapper.construct_successes("input")
+            .tap_successes(probe, "extra", extra_kw="kw")
+            .core
+        )
+        assert output == ("success", ("input",))
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
 
 
 class TestAwaitableResultWrapper:
@@ -212,6 +244,16 @@ class TestAwaitableResultWrapper:
             is failure
         )
 
+    async def test_map_success_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value="mapped")
+        output = (
+            await AwaitableResultWrapper.construct_success("input")
+            .map_success(probe, "extra", extra_kw="kw")
+            .core
+        )
+        assert output == ("success", "mapped")
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
     @pytest.mark.parametrize("value", _FLOATS)
     async def test_map_success_maps_success_value(self, value: float) -> None:
         assert await AwaitableResultWrapper.construct_success(value).map_success(
@@ -283,6 +325,38 @@ class TestAwaitableResultWrapper:
             _get_square_root_safely
         ).core == _get_square_root_safely(value)
 
+    async def test_tap_success_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value=None)
+        output = (
+            await AwaitableResultWrapper.construct_success("input")
+            .tap_success(probe, "extra", extra_kw="kw")
+            .core
+        )
+        assert output == ("success", "input")
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+
+class TestAwaitableTupleWrapper:
+    async def test_map_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value="mapped")
+        output = (
+            await AwaitableTupleWrapper.construct("input")
+            .map(probe, "extra", extra_kw="kw")
+            .core
+        )
+        assert output == ("mapped",)
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+    async def test_tap_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value=None)
+        output = (
+            await AwaitableTupleWrapper.construct("input")
+            .tap(probe, "extra", extra_kw="kw")
+            .core
+        )
+        assert output == ("input",)
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
 
 class TestAwaitableWrapper:
     @pytest.mark.parametrize("value", _OBJECTS)
@@ -312,6 +386,16 @@ class TestAwaitableWrapper:
             value
         )
 
+    async def test_map_to_awaitable_forwards_args_and_kwargs(self) -> None:
+        probe = AsyncMock(return_value="mapped")
+        output = (
+            await AwaitableWrapper.construct("input")
+            .map_to_awaitable(probe, "extra", extra_kw="kw")
+            .core
+        )
+        assert output == "mapped"
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
     @pytest.mark.parametrize("value", _FLOATS)
     async def test_map_to_awaitable_maps_value(self, value: float) -> None:
         assert await AwaitableWrapper.construct(value).map_to_awaitable(
@@ -329,6 +413,38 @@ class TestAwaitableWrapper:
         assert await AwaitableWrapper.construct(value).map_to_result(
             _get_square_root_safely
         ).core == _get_square_root_safely(value)
+
+    async def test_tap_to_awaitable_forwards_args_and_kwargs(self) -> None:
+        probe = AsyncMock(return_value=None)
+        output = (
+            await AwaitableWrapper.construct("input")
+            .tap_to_awaitable(probe, "extra", extra_kw="kw")
+            .core
+        )
+        assert output == "input"
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+
+class TestResultTupleWrapper:
+    def test_map_successes_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value="mapped")
+        output = (
+            ResultTupleWrapper.construct_successes("input")
+            .map_successes(probe, "extra", extra_kw="kw")
+            .core
+        )
+        assert output == ("success", ("mapped",))
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+    def test_tap_successes_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value=None)
+        output = (
+            ResultTupleWrapper.construct_successes("input")
+            .tap_successes(probe, "extra", extra_kw="kw")
+            .core
+        )
+        assert output == ("success", ("input",))
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
 
 
 class TestResultWrapper:
@@ -424,6 +540,16 @@ class TestResultWrapper:
         failure: Final = ("failure", value)
         assert ResultWrapper(failure).map_success(_double).core is failure
 
+    def test_map_success_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value="mapped")
+        output = (
+            ResultWrapper.construct_success("input")
+            .map_success(probe, "extra", extra_kw="kw")
+            .core
+        )
+        assert output == ("success", "mapped")
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
     @pytest.mark.parametrize("value", _FLOATS)
     def test_map_success_maps_success_value(self, value: float) -> None:
         assert ResultWrapper.construct_success(value).map_success(_double).core == (
@@ -492,11 +618,41 @@ class TestResultWrapper:
     def test_result_wrapper_wraps_result(self, result: Result[object, object]) -> None:
         assert ResultWrapper(result).core is result
 
+    def test_tap_success_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value=None)
+        output = (
+            ResultWrapper.construct_success("input")
+            .tap_success(probe, "extra", extra_kw="kw")
+            .core
+        )
+        assert output == ("success", "input")
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+
+class TestTupleWrapper:
+    def test_map_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value="mapped")
+        output = TupleWrapper.construct("input").map(probe, "extra", extra_kw="kw").core
+        assert output == ("mapped",)
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
+    def test_tap_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value=None)
+        output = TupleWrapper.construct("input").tap(probe, "extra", extra_kw="kw").core
+        assert output == ("input",)
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
+
 
 class TestWrapper:
     @pytest.mark.parametrize("value", _OBJECTS)
     def test_construct_wraps_value(self, value: object) -> None:
         assert Wrapper.construct(value).core is value
+
+    def test_map_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value="mapped")
+        output = Wrapper.construct("input").map(probe, "extra", extra_kw="kw").core
+        assert output == "mapped"
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
 
     @pytest.mark.parametrize("value", _FLOATS)
     def test_map_maps_value(self, value: float) -> None:
@@ -519,6 +675,12 @@ class TestWrapper:
         assert Wrapper(value).map_to_result(
             _get_square_root_safely
         ).core == _get_square_root_safely(value)
+
+    def test_tap_forwards_args_and_kwargs(self) -> None:
+        probe = Mock(return_value=None)
+        output = Wrapper.construct("input").tap(probe, "extra", extra_kw="kw").core
+        assert output == "input"
+        probe.assert_called_once_with("input", "extra", extra_kw="kw")
 
     @pytest.mark.parametrize("value", _OBJECTS)
     def test_wrapper_wraps_value(self, value: object) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1393,7 +1393,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'mypy'", specifier = ">=1.20" },
     { name = "pyrefly", marker = "extra == 'pyrefly'", specifier = ">=1.2" },
     { name = "pyright", marker = "python_full_version >= '3.14' and extra == 'pyright'", specifier = ">=1.1.407" },
-    { name = "pyright", marker = "extra == 'pyright'", specifier = ">=1.1.391" },
+    { name = "pyright", marker = "extra == 'pyright'", specifier = ">=1.1.392" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.12" },
 ]
 provides-extras = ["mypy", "pyrefly", "pyright"]


### PR DESCRIPTION
Extend every map*/tap* function in trcks.fp.monads and every corresponding method in trcks.oop wrapper classes with ParamSpec/Concatenate-based *args/**kwargs forwarding to the wrapped callable, so extra arguments no longer require a lambda or functools.partial.

Update docs/usage/fp/async.md, docs/usage/oop/async.md, and docs/glossary.md to showcase and document this capability.